### PR TITLE
Ingress port changed to https to match a named service port

### DIFF
--- a/step-certificates/templates/ingress.yaml
+++ b/step-certificates/templates/ingress.yaml
@@ -30,7 +30,7 @@ spec:
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: https
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
a fix in order to deploy helm chart with ingress enabled