### PR TITLE
Check .Values.autocert.enabled before include

### DIFF
--- a/step-certificates/templates/rbac.yaml
+++ b/step-certificates/templates/rbac.yaml
@@ -35,6 +35,7 @@ roleRef:
   name: {{ include "step-certificates.fullname" . }}-config
   apiGroup: rbac.authorization.k8s.io
 ---
+{{ if .Values.autocert.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -69,4 +70,5 @@ roleRef:
   kind: ClusterRole
   name: {{ include "step-certificates.fullname" . }}-config
   apiGroup: rbac.authorization.k8s.io
+{{- end -}} # if .Values.autocert.enabled
 {{- end -}}


### PR DESCRIPTION
Do not include `CluterRole` and `ClusterRoleBinding` for `mutatingwebhookconfigurations` resource, if `.Values.autocert.enabled` is set to false.
(Fixes #11 )