### PR TITLE
Add post-init script hook

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -59,6 +59,7 @@ chart and their default values.
 | `ca.db.accessModes`         | Persistent volume access mode                                                     | `["ReadWriteOnce"]`           |
 | `ca.db.size`                | Persistent volume size                                                            | `10Gi`                        |
 | `ca.runAsRoot`              | Run the CA as root.                                                               | `false`                       |
+| `ca.bootstrap.postInitHook` | Extra script snippet to run after `step ca init` has completed.                   | `""`                          |
 | `service.type`              | Service type                                                                      | `ClusterIP`                   |
 | `service.port`              | Incoming port to access Step CA                                                   | `443`                         |
 | `service.targetPort`        | Internal port where Step CA runs                                                  | `9000`                        |

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -111,6 +111,10 @@ data:
 
     rm -f $TMP_CA_PASSWORD $TMP_CA_PROVISIONER_PASSWORD
 
+{{- if .Values.ca.bootstrap.postInitHook }}
+{{ .Values.ca.bootstrap.postInitHook | indent 4 }}
+{{- end }}
+
     echo -e "\n\e[1mCreating configmaps and secrets in {{.Release.Namespace}} namespace ...\e[0m"
 
     # Replace secrets created on helm install

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -67,6 +67,9 @@ ca:
   # runAsRoot runs the ca as root instead of the step user. This is required in
   # some storage provisioners.
   runAsRoot: false
+  bootstrap:
+    # Add script snippets here to be executed after the step ca init has been run
+    postInitHook: ""
 
 # autocert is used to configure the autocert chart that depends on step-certificates.
 autocert:


### PR DESCRIPTION
In order to perform any custom initialisation after the step ca init has been
performed, allow execution of a script snippet provided in the config map via
helm values.