### PR TITLE
Remove "Release.IsInstall" on RBAC creation.

### DIFF
--- a/autocert/templates/rbac.yaml
+++ b/autocert/templates/rbac.yaml
@@ -1,4 +1,3 @@
-{{- if .Release.IsInstall -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,4 +23,3 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: {{ .Release.Namespace }}
-{{- end }}


### PR DESCRIPTION
RBAC should be present even when the install is being updated otherwise
the RBAC ClusterRole and ClusterRoleBinding are deleted.

Fixes https://github.com/smallstep/helm-charts/issues/18