### PR TITLE
introduce more configurable options for service type

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.15.6
+version: 1.16.0
 appVersion: 0.15.6
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -62,6 +62,7 @@ chart and their default values.
 | `ca.runAsRoot`                      | Run the CA as root.                                                                                         | `false`                       |
 | `ca.bootstrap.postInitHook`         | Extra script snippet to run after `step ca init` has completed.                                             | `""`                          |
 | `service.type`                      | Service type                                                                                                | `ClusterIP`                   |
+| `service.annotations`               | Service Annotations                                                                                         | `ClusterIP`                   |
 | `service.externalIPs`               | Incoming externalIP to assign to Step CA                                                                    | `[]`                          |
 | `service.loadBalancerIP`            | Incoming loadBalancerIP to assign to Step CA                                                                | `""`                          |
 | `service.loadBalancerSourceRanges`  | Incoming loadBalancerSourceRanges to assign to Step CA                                                      | `[]`                          |

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -45,45 +45,50 @@ deletes the release.
 The following table lists the configurable parameters of the Step certificates
 chart and their default values.
 
-| Parameter                   | Description                                                                                                 | Default                       |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `ca.name`                   | Name for you CA                                                                                             | `Step Certificates`           |
-| `ca.address`                | TCP address where Step CA runs                                                                              | `:9000`                       |
-| `ca.dns`                    | DNS of Step CA, if empty it will be inferred                                                                | `""`                          |
-| `ca.url`                    | URL of Step CA, if empty it will be inferred                                                                | `""`                          |
-| `ca.password`               | Password for the CA keys, if empty it will be automatically generated                                       | `""`                          |
-| `ca.provisioner.name`       | Name for the default provisioner                                                                            | `admin`                       |
-| `ca.provisioner.password`   | Password for the default provisioner, if empty it will be automatically generated                           | `""`                          |
-| `ca.db.enabled`             | If true, step certificates will be configured with a database                                               | `true`                        |
-| `ca.db.persistent`          | If true a persistent volume will be used to store the db                                                    | `true`                        |
-| `ca.db.accessModes`         | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`           |
-| `ca.db.size`                | Persistent volume size                                                                                      | `10Gi`                        |
-| `ca.db.existingClaim`       | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                          |
-| `ca.runAsRoot`              | Run the CA as root.                                                                                         | `false`                       |
-| `ca.bootstrap.postInitHook` | Extra script snippet to run after `step ca init` has completed.                                             | `""`                          |
-| `service.type`              | Service type                                                                                                | `ClusterIP`                   |
-| `service.port`              | Incoming port to access Step CA                                                                             | `443`                         |
-| `service.targetPort`        | Internal port where Step CA runs                                                                            | `9000`                        |
-| `replicaCount`              | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                           |
-| `image.repository`          | Repository of the Step CA image                                                                             | `smallstep/step-ca`           |
-| `image.tag`                 | Tag of the Step CA image                                                                                    | `latest`                      |
-| `image.pullPolicy`          | Step CA image pull policy                                                                                   | `IfNotPresent`                |
-| `bootstrap.image.repository`| Repository of the Step CA bootstrap image                                                                   | `smallstep/step-ca-bootstrap` |
-| `bootstrap.image.tag`       | Tag of the Step CA bootstrap image                                                                          | `latest`                      |
-| `bootstrap.image.pullPolicy`| Step CA bootstrap image pull policy                                                                         | `IfNotPresent`                |
-| `bootstrap.enabled`         | If false, it does not create the bootstrap job.                                                             | `true`                        |
-| `bootstrap.configmaps`      | If false, it does not create the configmaps.                                                                | `true`                        |
-| `bootstrap.secrets`         | If false, it does not create the secrets.                                                                   | `true`                        |
-| `nameOverride`              | Overrides the name of the chart                                                                             | `""`                          |
-| `fullnameOverride`          | Overrides the full name of the chart                                                                        | `""`                          |
-| `ingress.enabled`           | If true Step CA ingress will be created                                                                     | `false`                       |
-| `ingress.annotations`       | Step CA ingress annotations (YAML)                                                                          | `{}`                          |
-| `ingress.hosts`             | Step CA ingress hostNAMES (YAML)                                                                            | `[]`                          |
-| `ingress.tls`               | Step CA ingress TLS configuration (YAML)                                                                    | `[]`                          |
-| `resources`                 | CPU/memory resource requests/limits (YAML)                                                                  | `{}`                          |
-| `nodeSelector`              | Node labels for pod assignment (YAML)                                                                       | `{}`                          |
-| `tolerations`               | Toleration labels for pod assignment (YAML)                                                                 | `[]`                          |
-| `affinity`                  | Affinity settings for pod assignment (YAML)                                                                 | `{}`                          |
+| Parameter                           | Description                                                                                                 | Default                       |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `ca.name`                           | Name for you CA                                                                                             | `Step Certificates`           |
+| `ca.address`                        | TCP address where Step CA runs                                                                              | `:9000`                       |
+| `ca.dns`                            | DNS of Step CA, if empty it will be inferred                                                                | `""`                          |
+| `ca.url`                            | URL of Step CA, if empty it will be inferred                                                                | `""`                          |
+| `ca.password`                       | Password for the CA keys, if empty it will be automatically generated                                       | `""`                          |
+| `ca.provisioner.name`               | Name for the default provisioner                                                                            | `admin`                       |
+| `ca.provisioner.password`           | Password for the default provisioner, if empty it will be automatically generated                           | `""`                          |
+| `ca.db.enabled`                     | If true, step certificates will be configured with a database                                               | `true`                        |
+| `ca.db.persistent`                  | If true a persistent volume will be used to store the db                                                    | `true`                        |
+| `ca.db.accessModes`                 | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`           |
+| `ca.db.size`                        | Persistent volume size                                                                                      | `10Gi`                        |
+| `ca.db.existingClaim`               | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                          |
+| `ca.runAsRoot`                      | Run the CA as root.                                                                                         | `false`                       |
+| `ca.bootstrap.postInitHook`         | Extra script snippet to run after `step ca init` has completed.                                             | `""`                          |
+| `service.type`                      | Service type                                                                                                | `ClusterIP`                   |
+| `service.externalIPs`               | Incoming externalIP to assign to Step CA                                                                    | `[]`                          |
+| `service.loadBalancerIP`            | Incoming loadBalancerIP to assign to Step CA                                                                | `""`                          |
+| `service.loadBalancerSourceRanges`  | Incoming loadBalancerSourceRanges to assign to Step CA                                                      | `[]`                          |
+| `service.externalTrafficPolicy`     | Incoming externalTrafficPolicy to assign to Step CA                                                         | `""`                          |
+| `service.sessionAffinity`           | Incoming sessionAffinity to assign to Step CA                                                               | `""`                          |
+| `service.port`                      | Incoming port to access Step CA                                                                             | `443`                         |
+| `service.targetPort`                | Internal port where Step CA runs                                                                            | `9000`                        |
+| `replicaCount`                      | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                           |
+| `image.repository`                  | Repository of the Step CA image                                                                             | `smallstep/step-ca`           |
+| `image.tag`                         | Tag of the Step CA image                                                                                    | `latest`                      |
+| `image.pullPolicy`                  | Step CA image pull policy                                                                                   | `IfNotPresent`                |
+| `bootstrap.image.repository`        | Repository of the Step CA bootstrap image                                                                   | `smallstep/step-ca-bootstrap` |
+| `bootstrap.image.tag`               | Tag of the Step CA bootstrap image                                                                          | `latest`                      |
+| `bootstrap.image.pullPolicy`        | Step CA bootstrap image pull policy                                                                         | `IfNotPresent`                |
+| `bootstrap.enabled`                 | If false, it does not create the bootstrap job.                                                             | `true`                        |
+| `bootstrap.configmaps`              | If false, it does not create the configmaps.                                                                | `true`                        |
+| `bootstrap.secrets`                 | If false, it does not create the secrets.                                                                   | `true`                        |
+| `nameOverride`                      | Overrides the name of the chart                                                                             | `""`                          |
+| `fullnameOverride`                  | Overrides the full name of the chart                                                                        | `""`                          |
+| `ingress.enabled`                   | If true Step CA ingress will be created                                                                     | `false`                       |
+| `ingress.annotations`               | Step CA ingress annotations (YAML)                                                                          | `{}`                          |
+| `ingress.hosts`                     | Step CA ingress hostNAMES (YAML)                                                                            | `[]`                          |
+| `ingress.tls`                       | Step CA ingress TLS configuration (YAML)                                                                    | `[]`                          |
+| `resources`                         | CPU/memory resource requests/limits (YAML)                                                                  | `{}`                          |
+| `nodeSelector`                      | Node labels for pod assignment (YAML)                                                                       | `{}`                          |
+| `tolerations`                       | Toleration labels for pod assignment (YAML)                                                                 | `[]`                          |
+| `affinity`                          | Affinity settings for pod assignment (YAML)                                                                 | `{}`                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -6,6 +6,23 @@ metadata:
     {{- include "step-certificates.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+{{- end }}
+{{- if .Values.service.sessionAffinity }}
+  sessionAffinity: "{{ .Values.service.sessionAffinity }}"
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "step-certificates.fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 spec:

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -35,6 +35,11 @@ service:
   type: ClusterIP
   port: 443
   targetPort: 9000
+  # externalIPs: []
+  # loadBalancerIP: ""
+  # loadBalancerSourceRanges: []
+  # externalTrafficPolicy: "local"
+  # sessionAffinity: ""
 
 # ca contains the certificate authority configuration.
 ca:

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -40,6 +40,7 @@ service:
   # loadBalancerSourceRanges: []
   # externalTrafficPolicy: "local"
   # sessionAffinity: ""
+  # annotations: 
 
 # ca contains the certificate authority configuration.
 ca:


### PR DESCRIPTION
Hello!

I need to host small-step on it's own LoadBalancerIP rather than an ingress controller as the ingress controller uses cert-manager to get a public cert from LE rather than the PKI chain that Small Step provides.

This PR introduces additional service options for Small Step but defaults to the current configuration.