### PR TITLE
Add support for running an SSH CA

### DIFF
--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -87,6 +87,10 @@ spec:
             mountPath: /home/step/db
             readOnly: false
           {{- end }}
+          {{- if .Values.ca.ssh }}
+          - name: templates-ssh
+            mountPath: /home/step/templates/ssh
+          {{- end }}
       volumes:
       - name: certs
         configMap:
@@ -103,6 +107,11 @@ spec:
       {{- if and .Values.ca.db.enabled (not .Values.ca.db.persistent) }}
       - name: database
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.ca.ssh }}
+      - name: templates-ssh
+        configMap:
+          name: {{ include "step-certificates.fullname" . }}-templates-ssh
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -27,6 +27,16 @@ metadata:
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 ---
+{{- if .Values.ca.ssh }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-templates-ssh
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
+---
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -108,7 +118,7 @@ data:
       --provisioner "{{.Values.ca.provisioner.name}}" \
       --with-ca-url "{{include "step-certificates.url" .}}" \
       --password-file "$TMP_CA_PASSWORD" \
-      --provisioner-password-file "$TMP_CA_PROVISIONER_PASSWORD" {{ if not .Values.ca.db.enabled }}--no-db{{ end }}
+      --provisioner-password-file "$TMP_CA_PROVISIONER_PASSWORD" {{ if not .Values.ca.db.enabled }}--no-db{{ end }} {{ if .Values.ca.ssh }}--ssh{{ end }}
 
     rm -f $TMP_CA_PASSWORD $TMP_CA_PROVISIONER_PASSWORD
 
@@ -123,6 +133,7 @@ data:
     kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-config --from-file $(step path)/config
     kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-certs --from-file $(step path)/certs
     kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-secrets --from-file $(step path)/secrets
+    kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-templates-ssh --from-file $(step path)/templates/ssh
 
     kbreplace -n {{ .Release.Namespace }} create secret generic {{ include "step-certificates.fullname" . }}-ca-password --from-literal "password=${CA_PASSWORD}"
     kbreplace -n {{ .Release.Namespace }} create secret generic {{ include "step-certificates.fullname" . }}-provisioner-password --from-literal "password=${CA_PROVISIONER_PASSWORD}"
@@ -131,6 +142,7 @@ data:
     kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-config {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-certs {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-secrets {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
+    kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-templates-ssh {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label secret {{ include "step-certificates.fullname" . }}-ca-password {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label secret {{ include "step-certificates.fullname" . }}-provisioner-password {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
 

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -50,6 +50,7 @@ ca:
   url:
   # password is the password used to encrypt the keys. Leave it empty to generate a random one.
   password:
+  ssh: false
   # provisioner contains the step-certificates provisioner configuration.
   provisioner:
     # name is the new provisioner name.


### PR DESCRIPTION
Fixes #2

This allows the bootstrap script to generate an SSH CA, and copies the templates required for the CA to run into a new `-templates-ssh` configmap