### PR TITLE
Use `cr.step.sm` endpoint for `smallstep/*` containers

### DIFF
--- a/autocert/README.md
+++ b/autocert/README.md
@@ -66,39 +66,39 @@ default       Active   59m   enabled
 The following table lists the configurable parameters of the Autocert chart and
 their default values.
 
-| Parameter                                  | Description                                                                       | Default                                 |
-|--------------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------|
-| `replicaCount`                             | Number of Autocert replicas                                                       | `1`                                     |
-| `nameOverride`                             | Overrides the name of the chart                                                   | `""`                                    |
-| `fullnameOverride`                         | Overrides the full name of the chart                                              | `""`                                    |
-| `service.type`                             | Service type                                                                      | `ClusterIP`                             |
-| `service.port`                             | Incoming port to access Autocert                                                  | `443`                                   |
-| `service.targetPort`                       | Internal port where Autocert runs                                                 | `4443`                                  |
-| `autocert.image.repository`                | Repository of the Autocert image                                                  | `smallstep/autocert-controller`         |
-| `autocert.image.tag`                       | Tag of the Autocert image                                                         | `0.12.2`                                |
-| `autocert.image.pullPolicy`                | Autocert image pull policy                                                        | `IfNotPresent`                          |
-| `autocert.label`                           | Label uses to enable Autocert in a namespaces (should not be changed)             | `autocert.step.sm`                      |
-| `autocert.logFormat`                       | Log format, `json` or `text`                                                      | `json`                                  |
-| `autocert.restrictCertificatesToNamespace` | If certificate names are restricted to the namespace                              | `false`                                 |
-| `autocert.closterDomain`                   | Cluster domain name                                                               | `cluster.local`                         |
-| `autocert.certLifetime`                    | Certificate lifetime                                                              | `24h`                                   |
-| `autocert.resources`                       | CPU/memory resource requests/limits (YAML)                                        | `{requests: {cpu: 100m, memory: 20Mi}}` |
-| `autocert.nodeSelector`                    | Node labels for pod assignment (YAML)                                             | `{}`                                    |
-| `autocert.tolerations`                     | Toleration labels for pod assignment (YAML)                                       | `[]`                                    |
-| `autocert.affinity`                        | Affinity settings for pod assignment (YAML)                                       | `{}`                                    |
-| `bootstrapper.image.repository`            | Repository of the Autocert bootstrapper image                                     | `smallstep/autocert-bootstrapper`       |
-| `bootstrapper.image.tag`                   | Tag of the Autocert bootstrapper image                                            | `0.12.2`                                |
-| `bootstrapper.image.pullPolicy`            | Autocert bootstrapper image pull policy                                           | `IfNotPresent`                          |
-| `bootstrapper.resources`                   | CPU/memory resource requests/limits (YAML)                                        | `{}`                                    |
-| `renewer.image.repository`                 | Repository of the Autocert renewer image                                          | `smallstep/autocert-renewer`            |
-| `renewer.image.tag`                        | Tag of the Autocert renewer image                                                 | `0.12.2`                                |
-| `renewer.image.pullPolicy`                 | Autocert renewer image pull policy                                                | `IfNotPresent`                          |
-| `renewer.resources`                        | CPU/memory resource requests/limits (YAML)                                        | `{}`                                    |
-| `ingress.enabled`                          | If true Autocert ingress will be created                                          | `false`                                 |
-| `ingress.annotations`                      | Autocert ingress annotations (YAML)                                               | `{}`                                    |
-| `ingress.hosts`                            | Autocert ingress hostNAMES (YAML)                                                 | `[]`                                    |
-| `ingress.tls`                              | Autocert ingress TLS configuration (YAML)                                         | `[]`                                    |
-| `step-certificates.autocert.enabled`       | Enables autocert in step-certificates sub-chart (should not be changed)           | `true`                                  |
+| Parameter                                  | Description                                                                       | Default                                       |
+|--------------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------------|
+| `replicaCount`                             | Number of Autocert replicas                                                       | `1`                                           |
+| `nameOverride`                             | Overrides the name of the chart                                                   | `""`                                          |
+| `fullnameOverride`                         | Overrides the full name of the chart                                              | `""`                                          |
+| `service.type`                             | Service type                                                                      | `ClusterIP`                                   |
+| `service.port`                             | Incoming port to access Autocert                                                  | `443`                                         |
+| `service.targetPort`                       | Internal port where Autocert runs                                                 | `4443`                                        |
+| `autocert.image.repository`                | Repository of the Autocert image                                                  | `cr.step.sm/smallstep/autocert-controller`    |
+| `autocert.image.tag`                       | Tag of the Autocert image                                                         | `0.12.2`                                      |
+| `autocert.image.pullPolicy`                | Autocert image pull policy                                                        | `IfNotPresent`                                |
+| `autocert.label`                           | Label uses to enable Autocert in a namespaces (should not be changed)             | `autocert.step.sm`                            |
+| `autocert.logFormat`                       | Log format, `json` or `text`                                                      | `json`                                        |
+| `autocert.restrictCertificatesToNamespace` | If certificate names are restricted to the namespace                              | `false`                                       |
+| `autocert.closterDomain`                   | Cluster domain name                                                               | `cluster.local`                               |
+| `autocert.certLifetime`                    | Certificate lifetime                                                              | `24h`                                         |
+| `autocert.resources`                       | CPU/memory resource requests/limits (YAML)                                        | `{requests: {cpu: 100m, memory: 20Mi}}`       |
+| `autocert.nodeSelector`                    | Node labels for pod assignment (YAML)                                             | `{}`                                          |
+| `autocert.tolerations`                     | Toleration labels for pod assignment (YAML)                                       | `[]`                                          |
+| `autocert.affinity`                        | Affinity settings for pod assignment (YAML)                                       | `{}`                                          |
+| `bootstrapper.image.repository`            | Repository of the Autocert bootstrapper image                                     | `cr.step.sm/smallstep/autocert-bootstrapper`  |
+| `bootstrapper.image.tag`                   | Tag of the Autocert bootstrapper image                                            | `0.12.2`                                      |
+| `bootstrapper.image.pullPolicy`            | Autocert bootstrapper image pull policy                                           | `IfNotPresent`                                |
+| `bootstrapper.resources`                   | CPU/memory resource requests/limits (YAML)                                        | `{}`                                          |
+| `renewer.image.repository`                 | Repository of the Autocert renewer image                                          | `cr.step.sm/smallstep/autocert-renewer`       |
+| `renewer.image.tag`                        | Tag of the Autocert renewer image                                                 | `0.12.2`                                      |
+| `renewer.image.pullPolicy`                 | Autocert renewer image pull policy                                                | `IfNotPresent`                                |
+| `renewer.resources`                        | CPU/memory resource requests/limits (YAML)                                        | `{}`                                          |
+| `ingress.enabled`                          | If true Autocert ingress will be created                                          | `false`                                       |
+| `ingress.annotations`                      | Autocert ingress annotations (YAML)                                               | `{}`                                          |
+| `ingress.hosts`                            | Autocert ingress hostNAMES (YAML)                                                 | `[]`                                          |
+| `ingress.tls`                              | Autocert ingress TLS configuration (YAML)                                         | `[]`                                          |
+| `step-certificates.autocert.enabled`       | Enables autocert in step-certificates sub-chart (should not be changed)           | `true`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/autocert/values.yaml
+++ b/autocert/values.yaml
@@ -19,7 +19,7 @@ service:
 autocert:
   # image contains the docker image for step-certificates.
   image:
-    repository: smallstep/autocert-controller
+    repository: cr.step.sm/smallstep/autocert-controller
     tag: 0.12.2
     pullPolicy: IfNotPresent
   # label is the label used used to enable autocert in a namespace.
@@ -45,7 +45,7 @@ autocert:
 # bootstrapper contains the autocert-bootstrapper image and configuration.
 bootstrapper:
   image:
-    repository: smallstep/autocert-bootstrapper
+    repository: cr.step.sm/smallstep/autocert-bootstrapper
     tag: 0.12.2
     pullPolicy: IfNotPresent
   resources: {requests: {cpu: 10m, memory: 20Mi}}
@@ -53,7 +53,7 @@ bootstrapper:
 # renewer contains the autocert-renewer image and configuration.
 renewer:
   image:
-    repository: smallstep/autocert-renewer
+    repository: cr.step.sm/smallstep/autocert-renewer
     tag: 0.12.2
     pullPolicy: IfNotPresent
   resources: {requests: {cpu: 10m, memory: 20Mi}}

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -65,7 +65,7 @@ chart and their default values.
 | `service.port`              | Incoming port to access Step CA                                                                             | `443`                         |
 | `service.targetPort`        | Internal port where Step CA runs                                                                            | `9000`                        |
 | `replicaCount`              | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                           |
-| `image.repository`          | Repository of the Step CA image                                                                             | `smallstep/step-ca`           |
+| `image.repository`          | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`|
 | `image.tag`                 | Tag of the Step CA image                                                                                    | `latest`                      |
 | `image.pullPolicy`          | Step CA image pull policy                                                                                   | `IfNotPresent`                |
 | `bootstrap.image.repository`| Repository of the Step CA bootstrap image                                                                   | `smallstep/step-ca-bootstrap` |

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -45,45 +45,45 @@ deletes the release.
 The following table lists the configurable parameters of the Step certificates
 chart and their default values.
 
-| Parameter                   | Description                                                                                                 | Default                       |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `ca.name`                   | Name for you CA                                                                                             | `Step Certificates`           |
-| `ca.address`                | TCP address where Step CA runs                                                                              | `:9000`                       |
-| `ca.dns`                    | DNS of Step CA, if empty it will be inferred                                                                | `""`                          |
-| `ca.url`                    | URL of Step CA, if empty it will be inferred                                                                | `""`                          |
-| `ca.password`               | Password for the CA keys, if empty it will be automatically generated                                       | `""`                          |
-| `ca.provisioner.name`       | Name for the default provisioner                                                                            | `admin`                       |
-| `ca.provisioner.password`   | Password for the default provisioner, if empty it will be automatically generated                           | `""`                          |
-| `ca.db.enabled`             | If true, step certificates will be configured with a database                                               | `true`                        |
-| `ca.db.persistent`          | If true a persistent volume will be used to store the db                                                    | `true`                        |
-| `ca.db.accessModes`         | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`           |
-| `ca.db.size`                | Persistent volume size                                                                                      | `10Gi`                        |
-| `ca.db.existingClaim`       | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                          |
-| `ca.runAsRoot`              | Run the CA as root.                                                                                         | `false`                       |
-| `ca.bootstrap.postInitHook` | Extra script snippet to run after `step ca init` has completed.                                             | `""`                          |
-| `service.type`              | Service type                                                                                                | `ClusterIP`                   |
-| `service.port`              | Incoming port to access Step CA                                                                             | `443`                         |
-| `service.targetPort`        | Internal port where Step CA runs                                                                            | `9000`                        |
-| `replicaCount`              | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                           |
-| `image.repository`          | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`|
-| `image.tag`                 | Tag of the Step CA image                                                                                    | `latest`                      |
-| `image.pullPolicy`          | Step CA image pull policy                                                                                   | `IfNotPresent`                |
-| `bootstrap.image.repository`| Repository of the Step CA bootstrap image                                                                   | `smallstep/step-ca-bootstrap` |
-| `bootstrap.image.tag`       | Tag of the Step CA bootstrap image                                                                          | `latest`                      |
-| `bootstrap.image.pullPolicy`| Step CA bootstrap image pull policy                                                                         | `IfNotPresent`                |
-| `bootstrap.enabled`         | If false, it does not create the bootstrap job.                                                             | `true`                        |
-| `bootstrap.configmaps`      | If false, it does not create the configmaps.                                                                | `true`                        |
-| `bootstrap.secrets`         | If false, it does not create the secrets.                                                                   | `true`                        |
-| `nameOverride`              | Overrides the name of the chart                                                                             | `""`                          |
-| `fullnameOverride`          | Overrides the full name of the chart                                                                        | `""`                          |
-| `ingress.enabled`           | If true Step CA ingress will be created                                                                     | `false`                       |
-| `ingress.annotations`       | Step CA ingress annotations (YAML)                                                                          | `{}`                          |
-| `ingress.hosts`             | Step CA ingress hostNAMES (YAML)                                                                            | `[]`                          |
-| `ingress.tls`               | Step CA ingress TLS configuration (YAML)                                                                    | `[]`                          |
-| `resources`                 | CPU/memory resource requests/limits (YAML)                                                                  | `{}`                          |
-| `nodeSelector`              | Node labels for pod assignment (YAML)                                                                       | `{}`                          |
-| `tolerations`               | Toleration labels for pod assignment (YAML)                                                                 | `[]`                          |
-| `affinity`                  | Affinity settings for pod assignment (YAML)                                                                 | `{}`                          |
+| Parameter                   | Description                                                                                                 | Default                                  |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `ca.name`                   | Name for you CA                                                                                             | `Step Certificates`                      |
+| `ca.address`                | TCP address where Step CA runs                                                                              | `:9000`                                  |
+| `ca.dns`                    | DNS of Step CA, if empty it will be inferred                                                                | `""`                                     |
+| `ca.url`                    | URL of Step CA, if empty it will be inferred                                                                | `""`                                     |
+| `ca.password`               | Password for the CA keys, if empty it will be automatically generated                                       | `""`                                     |
+| `ca.provisioner.name`       | Name for the default provisioner                                                                            | `admin`                                  |
+| `ca.provisioner.password`   | Password for the default provisioner, if empty it will be automatically generated                           | `""`                                     |
+| `ca.db.enabled`             | If true, step certificates will be configured with a database                                               | `true`                                   |
+| `ca.db.persistent`          | If true a persistent volume will be used to store the db                                                    | `true`                                   |
+| `ca.db.accessModes`         | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
+| `ca.db.size`                | Persistent volume size                                                                                      | `10Gi`                                   |
+| `ca.db.existingClaim`       | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
+| `ca.runAsRoot`              | Run the CA as root.                                                                                         | `false`                                  |
+| `ca.bootstrap.postInitHook` | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
+| `service.type`              | Service type                                                                                                | `ClusterIP`                              |
+| `service.port`              | Incoming port to access Step CA                                                                             | `443`                                    |
+| `service.targetPort`        | Internal port where Step CA runs                                                                            | `9000`                                   |
+| `replicaCount`              | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
+| `image.repository`          | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
+| `image.tag`                 | Tag of the Step CA image                                                                                    | `latest`                                 |
+| `image.pullPolicy`          | Step CA image pull policy                                                                                   | `IfNotPresent`                           |
+| `bootstrap.image.repository`| Repository of the Step CA bootstrap image                                                                   | `cr.step.sm/smallstep/step-ca-bootstrap` |
+| `bootstrap.image.tag`       | Tag of the Step CA bootstrap image                                                                          | `latest`                                 |
+| `bootstrap.image.pullPolicy`| Step CA bootstrap image pull policy                                                                         | `IfNotPresent`                           |
+| `bootstrap.enabled`         | If false, it does not create the bootstrap job.                                                             | `true`                                   |
+| `bootstrap.configmaps`      | If false, it does not create the configmaps.                                                                | `true`                                   |
+| `bootstrap.secrets`         | If false, it does not create the secrets.                                                                   | `true`                                   |
+| `nameOverride`              | Overrides the name of the chart                                                                             | `""`                                     |
+| `fullnameOverride`          | Overrides the full name of the chart                                                                        | `""`                                     |
+| `ingress.enabled`           | If true Step CA ingress will be created                                                                     | `false`                                  |
+| `ingress.annotations`       | Step CA ingress annotations (YAML)                                                                          | `{}`                                     |
+| `ingress.hosts`             | Step CA ingress hostNAMES (YAML)                                                                            | `[]`                                     |
+| `ingress.tls`               | Step CA ingress TLS configuration (YAML)                                                                    | `[]`                                     |
+| `resources`                 | CPU/memory resource requests/limits (YAML)                                                                  | `{}`                                     |
+| `nodeSelector`              | Node labels for pod assignment (YAML)                                                                       | `{}`                                     |
+| `tolerations`               | Toleration labels for pod assignment (YAML)                                                                 | `[]`                                     |
+| `affinity`                  | Affinity settings for pod assignment (YAML)                                                                 | `{}`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 
 # image contains the docker image for step-certificates.
 image:
-  repository: smallstep/step-ca
+  repository: cr.step.sm/smallstep/step-ca
   tag: 0.15.6
   pullPolicy: IfNotPresent
 

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -20,7 +20,7 @@ image:
 # It's also possible to disable the creation of secrets and configmaps.
 bootstrap:
   image:
-    repository: smallstep/step-ca-bootstrap
+    repository: cr.step.sm/smallstep/step-ca-bootstrap
     tag: latest
     pullPolicy: IfNotPresent
   # enabled defines if the bootstrap job is created.

--- a/step-issuer/README.md
+++ b/step-issuer/README.md
@@ -42,15 +42,15 @@ deletes the release.
 The following table lists the configurable parameters of the Step Issuer chart
 and their default values.
 
-| Parameter                                 | Description                                                              | Default                 |
-| ----------------------------------------- | ------------------------------------------------------------------------ | ----------------------- |
-| `replicaCount`                            | Number of Step Issuer replicas.                                          | `1`                     |
-| `deployment.image.repository`             | Repository of the Step Issuer image.                                     | `smallstep/step-issuer` |
-| `deployment.image.tag`                    | Tag of the Step Step Issuer image .                                      | `0.2.0`                 |
-| `deployment.image.pullPolicy`             | Step Issuer image pull policy                                            | `IfNotPresent`          |
-| `stepIssuer.created`                      | If we should automatically create an step-issuer.                        | `false`                 |
-| `stepIssuer.caBundler`                    | Step Certificates root certificate in base64.                            | `""`                    |
-| `stepIssuer.provisioner.name`             | Name of the provisioner used for authorizing the sign of certificates.   | `""`                    |
-| `stepIssuer.provisioner.kid`              | Key id of the provisioner used for authorizing the sign of certificates. | `""`                    |
-| `stepIssuer.provisioner.passwordRef.name` | Name of the secret with the provisioner password.                        | `""`                    |
-| `stepIssuer.provisioner.passwordRef.key`  | Key name in the the secret with the provisioner password.                | `""`                    |
+| Parameter                                 | Description                                                              | Default                             |
+| ----------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------- |
+| `replicaCount`                            | Number of Step Issuer replicas.                                          | `1`                                 |
+| `deployment.image.repository`             | Repository of the Step Issuer image.                                     | `cr.step.sm/smallstep/step-issuer`  |
+| `deployment.image.tag`                    | Tag of the Step Step Issuer image .                                      | `0.2.0`                             |
+| `deployment.image.pullPolicy`             | Step Issuer image pull policy                                            | `IfNotPresent`                      |
+| `stepIssuer.created`                      | If we should automatically create an step-issuer.                        | `false`                             |
+| `stepIssuer.caBundler`                    | Step Certificates root certificate in base64.                            | `""`                                |
+| `stepIssuer.provisioner.name`             | Name of the provisioner used for authorizing the sign of certificates.   | `""`                                |
+| `stepIssuer.provisioner.kid`              | Key id of the provisioner used for authorizing the sign of certificates. | `""`                                |
+| `stepIssuer.provisioner.passwordRef.name` | Name of the secret with the provisioner password.                        | `""`                                |
+| `stepIssuer.provisioner.passwordRef.key`  | Key name in the the secret with the provisioner password.                | `""`                                |

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 deployment:
   image:
-    repository: smallstep/step-issuer
+    repository: cr.step.sm/smallstep/step-issuer
     pullPolicy: IfNotPresent
     # custom add from deployments
     tag: 0.2.0


### PR DESCRIPTION
cc @mmalone @alanchrt 

This change updates all charts to use the new `cr.step.sm` endpoint for all `smallstep/*` containers. This change is scoped to `values.yml` files to update the repository values, as well as updating the corresponding READMEs per chart.

Let me know if I missed anything. Thanks!