### PR TITLE
fixes of broken helm chart and pullsecrets

### DIFF
--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -15,6 +15,12 @@ spec:
       labels:
         control-plane: {{ .Values.service.controlPlane }}
     spec:
+      {{- if $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range $key := $.Values.imagePullSecrets }}
+        - name: {{ $key }}
+        {{- end }}
+      {{- end }}
       containers:
       - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
         name: kube-rbac-proxy

--- a/step-issuer/templates/rbac/clusterRole.yaml
+++ b/step-issuer/templates/rbac/clusterRole.yaml
@@ -21,20 +21,13 @@ rules:
   resources: ["stepissuers"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 - apiGroups: ["certmanager.step.sm"]
-  resources: ["stepclusterissuers"]
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
-- apiGroups: ["certmanager.step.sm"]
   resources: ["stepissuers/status"]
-  verbs: ["get", "patch", "update"]
-- apiGroups: ["certmanager.step.sm"]
-  resources: ["stepclusterissuers/status"]
   verbs: ["get", "patch", "update"]
 - apiGroups: ["cert-manager.io"]
   resources: ["signers"]
   verbs: ["approve"]
   resourceNames: 
     - stepissuers.certmanager.step.sm/*
-    - stepclusterissuers.certmanager.step.sm/*
 - apiGroups: [ "coordination.k8s.io" ]
   resources: [ "leases" ]
   verbs: [ "create", "get", "list", "update" ]
@@ -64,4 +57,3 @@ rules:
   - approve
   resourceNames:
   - stepissuers.certmanager.step.sm/*
-  - stepclusterissuers.certmanager.step.sm/*

--- a/step-issuer/templates/rbac/clusterRole.yaml
+++ b/step-issuer/templates/rbac/clusterRole.yaml
@@ -21,12 +21,23 @@ rules:
   resources: ["stepissuers"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 - apiGroups: ["certmanager.step.sm"]
+  resources: ["stepclusterissuers"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["certmanager.step.sm"]
   resources: ["stepissuers/status"]
+  verbs: ["get", "patch", "update"]
+- apiGroups: ["certmanager.step.sm"]
+  resources: ["stepclusterissuers/status"]
   verbs: ["get", "patch", "update"]
 - apiGroups: ["cert-manager.io"]
   resources: ["signers"]
   verbs: ["approve"]
-  resourceNames: ["stepissuers.certmanager.step.sm/*"]
+  resourceNames: 
+    - stepissuers.certmanager.step.sm/*
+    - stepclusterissuers.certmanager.step.sm/*
+- apiGroups: [ "coordination.k8s.io" ]
+  resources: [ "leases" ]
+  verbs: [ "create", "get", "list", "update" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39,3 +50,18 @@ rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ template "step-issuer.fullname" . }}-cert-manager-controller-approve:certmanager-step-sm"
+rules:
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - signers
+  verbs:
+  - approve
+  resourceNames:
+  - stepissuers.certmanager.step.sm/*
+  - stepclusterissuers.certmanager.step.sm/*

--- a/step-issuer/templates/rbac/clusterRoleBinding.yaml
+++ b/step-issuer/templates/rbac/clusterRoleBinding.yaml
@@ -24,3 +24,16 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ template "step-issuer.fullname" . }}-cert-manager-controller-approve:certmanager-step-sm"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ template "step-issuer.fullname" . }}-cert-manager-controller-approve:certmanager-step-sm"
+subjects:
+- kind: ServiceAccount
+  name: cert-manager
+  namespace: cert-manager


### PR DESCRIPTION
# Description

The current helm chart you released is completely broken, due to missing resources. This version also includes the addition for imagePullSecrets, which is necessary for the clusterIssuer we wrote.


Signed-off-by: Tobias Gurtzick <magic@wizardtales.com>