### PR TITLE
Adds ability to specify a nodePort.

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -63,6 +63,7 @@ chart and their default values.
 | `ca.bootstrap.postInitHook` | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
 | `service.type`              | Service type                                                                                                | `ClusterIP`                              |
 | `service.port`              | Incoming port to access Step CA                                                                             | `443`                                    |
+| `service.nodePort`          | Incoming port to access Step CA                                                                             | `""`                                     |
 | `service.targetPort`        | Internal port where Step CA runs                                                                            | `9000`                                   |
 | `replicaCount`              | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
 | `image.repository`          | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -11,6 +11,9 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: https
+      {{ if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "step-certificates.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -36,6 +36,7 @@ service:
   type: ClusterIP
   port: 443
   targetPort: 9000
+# nodePort: 32400
 
 # ca contains the certificate authority configuration.
 ca:

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -36,7 +36,7 @@ service:
   type: ClusterIP
   port: 443
   targetPort: 9000
-# nodePort: 32400
+  nodePort: ""
 
 # ca contains the certificate authority configuration.
 ca:


### PR DESCRIPTION
This change allows a user to specify the NodePort to be used rather than
having Kubernetes randomly assign one.

Example:

```yaml
values:
  service:
    type: NodePort
    port: 443
    nodePort: 32400
    targetPort: 9000
```

#43 