### PR TITLE
Add Capability to Inject Secrets, Configuration, Templates and Certificates

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -45,46 +45,62 @@ deletes the release.
 The following table lists the configurable parameters of the Step certificates
 chart and their default values.
 
-| Parameter                   | Description                                                                                                 | Default                                  |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `ca.name`                   | Name for you CA                                                                                             | `Step Certificates`                      |
-| `ca.address`                | TCP address where Step CA runs                                                                              | `:9000`                                  |
-| `ca.dns`                    | DNS of Step CA, if empty it will be inferred                                                                | `""`                                     |
-| `ca.url`                    | URL of Step CA, if empty it will be inferred                                                                | `""`                                     |
-| `ca.password`               | Password for the CA keys, if empty it will be automatically generated                                       | `""`                                     |
-| `ca.provisioner.name`       | Name for the default provisioner                                                                            | `admin`                                  |
-| `ca.provisioner.password`   | Password for the default provisioner, if empty it will be automatically generated                           | `""`                                     |
-| `ca.db.enabled`             | If true, step certificates will be configured with a database                                               | `true`                                   |
-| `ca.db.persistent`          | If true a persistent volume will be used to store the db                                                    | `true`                                   |
-| `ca.db.accessModes`         | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
-| `ca.db.size`                | Persistent volume size                                                                                      | `10Gi`                                   |
-| `ca.db.existingClaim`       | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
-| `ca.runAsRoot`              | Run the CA as root.                                                                                         | `false`                                  |
-| `ca.bootstrap.postInitHook` | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
-| `service.type`              | Service type                                                                                                | `ClusterIP`                              |
-| `service.port`              | Incoming port to access Step CA                                                                             | `443`                                    |
-| `service.nodePort`          | Incoming port to access Step CA                                                                             | `""`                                     |
-| `service.targetPort`        | Internal port where Step CA runs                                                                            | `9000`                                   |
-| `replicaCount`              | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
-| `image.repository`          | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
-| `image.tag`                 | Tag of the Step CA image                                                                                    | `latest`                                 |
-| `image.pullPolicy`          | Step CA image pull policy                                                                                   | `IfNotPresent`                           |
-| `bootstrap.image.repository`| Repository of the Step CA bootstrap image                                                                   | `cr.step.sm/smallstep/step-ca-bootstrap` |
-| `bootstrap.image.tag`       | Tag of the Step CA bootstrap image                                                                          | `latest`                                 |
-| `bootstrap.image.pullPolicy`| Step CA bootstrap image pull policy                                                                         | `IfNotPresent`                           |
-| `bootstrap.enabled`         | If false, it does not create the bootstrap job.                                                             | `true`                                   |
-| `bootstrap.configmaps`      | If false, it does not create the configmaps.                                                                | `true`                                   |
-| `bootstrap.secrets`         | If false, it does not create the secrets.                                                                   | `true`                                   |
-| `nameOverride`              | Overrides the name of the chart                                                                             | `""`                                     |
-| `fullnameOverride`          | Overrides the full name of the chart                                                                        | `""`                                     |
-| `ingress.enabled`           | If true Step CA ingress will be created                                                                     | `false`                                  |
-| `ingress.annotations`       | Step CA ingress annotations (YAML)                                                                          | `{}`                                     |
-| `ingress.hosts`             | Step CA ingress hostNAMES (YAML)                                                                            | `[]`                                     |
-| `ingress.tls`               | Step CA ingress TLS configuration (YAML)                                                                    | `[]`                                     |
-| `resources`                 | CPU/memory resource requests/limits (YAML)                                                                  | `{}`                                     |
-| `nodeSelector`              | Node labels for pod assignment (YAML)                                                                       | `{}`                                     |
-| `tolerations`               | Toleration labels for pod assignment (YAML)                                                                 | `[]`                                     |
-| `affinity`                  | Affinity settings for pod assignment (YAML)                                                                 | `{}`                                     |
+| Parameter                     | Description                                                                                                 | Default                                  |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `ca.name`                     | Name for you CA                                                                                             | `Step Certificates`                      |
+| `ca.address`                  | TCP address where Step CA runs                                                                              | `:9000`                                  |
+| `ca.dns`                      | DNS of Step CA, if empty it will be inferred                                                                | `""`                                     |
+| `ca.url`                      | URL of Step CA, if empty it will be inferred                                                                | `""`                                     |
+| `ca.password`                 | Password for the CA keys, if empty it will be automatically generated                                       | `""`                                     |
+| `ca.provisioner.name`         | Name for the default provisioner                                                                            | `admin`                                  |
+| `ca.provisioner.password`     | Password for the default provisioner, if empty it will be automatically generated                           | `""`                                     |
+| `ca.db.enabled`               | If true, step certificates will be configured with a database                                               | `true`                                   |
+| `ca.db.persistent`            | If true a persistent volume will be used to store the db                                                    | `true`                                   |
+| `ca.db.accessModes`           | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
+| `ca.db.size`                  | Persistent volume size                                                                                      | `10Gi`                                   |
+| `ca.db.existingClaim`         | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
+| `ca.runAsRoot`                | Run the CA as root.                                                                                         | `false`                                  |
+| `ca.bootstrap.postInitHook`   | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
+| `service.type`                | Service type                                                                                                | `ClusterIP`                              |
+| `service.port`                | Incoming port to access Step CA                                                                             | `443`                                    |
+| `service.nodePort`            | Incoming port to access Step CA                                                                             | `""`                                     |
+| `service.targetPort`          | Internal port where Step CA runs                                                                            | `9000`                                   |
+| `replicaCount`                | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
+| `image.repository`            | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
+| `image.tag`                   | Tag of the Step CA image                                                                                    | `latest`                                 |
+| `image.pullPolicy`            | Step CA image pull policy                                                                                   | `IfNotPresent`                           |
+| `bootstrap.image.repository`  | Repository of the Step CA bootstrap image                                                                   | `cr.step.sm/smallstep/step-ca-bootstrap` |
+| `bootstrap.image.tag`         | Tag of the Step CA bootstrap image                                                                          | `latest`                                 |
+| `bootstrap.image.pullPolicy`  | Step CA bootstrap image pull policy                                                                         | `IfNotPresent`                           |
+| `bootstrap.enabled`           | If false, it does not create the bootstrap job.                                                             | `true`                                   |
+| `bootstrap.configmaps`        | If false, it does not create the configmaps.                                                                | `true`                                   |
+| `bootstrap.secrets`           | If false, it does not create the secrets.                                                                   | `true`                                   |
+| `nameOverride`                | Overrides the name of the chart                                                                             | `""`                                     |
+| `fullnameOverride`            | Overrides the full name of the chart                                                                        | `""`                                     |
+| `ingress.enabled`             | If true Step CA ingress will be created                                                                     | `false`                                  |
+| `ingress.annotations`         | Step CA ingress annotations (YAML)                                                                          | `{}`                                     |
+| `ingress.hosts`               | Step CA ingress hostNAMES (YAML)                                                                            | `[]`                                     |
+| `ingress.tls`                 | Step CA ingress TLS configuration (YAML)                                                                    | `[]`                                     |
+| `resources`                   | CPU/memory resource requests/limits (YAML)                                                                  | `{}`                                     |
+| `nodeSelector`                | Node labels for pod assignment (YAML)                                                                       | `{}`                                     |
+| `tolerations`                 | Toleration labels for pod assignment (YAML)                                                                 | `[]`                                     |
+| `affinity`                    | Affinity settings for pod assignment (YAML)                                                                 | `{}`                                     |
+| `inject.config.enabled`       | When true, configuration files and templates are injected into a Kubernetes configmap.                      | `false`                                  |
+| `inject.config.files.ca.json` | Yaml representation of the step-ca ca.json file.  This map object is converted to its equivalent json representation before being injected into a configMap.  See the step-ca [documentation](https://smallstep.com/docs/step-ca/configuration). | See [values.yaml](./values.yaml) |
+| `inject.config.files.default.json` | Yaml representation of the step-cli defaults.json file.  This map object is converted to its equivalent json representation before being injected into a configMap.  See the step-cli [documentation](https://smallstep.com/docs/step-cli/reference). | See [values.yaml](./values.yaml) |
+| `inject.config.templates.x509_leaf.tpl`   | Example X509 Leaf Certifixate Template to inject into the configMap.                            | See [values.yaml](./values.yaml)         |
+| `inject.config.templates.ssh.tpl`         | Example SSH Certificate Template to inject into the configMap.                                  | See [values.yaml](./values.yaml)         |
+| `inject.certificates.enabled`             | When true, certificates are injected into a configmap.                                          | `false`                                  |
+| `inject.certificates.intermediate_ca`     | Plain text PEM representation of the intermediate CA certificate.                               | `""`                                     |
+| `inject.certificates.root_ca`             | Plain text PEM representation of the root CA certificate.                                       | `""`                                     |
+| `inject.certificates.ssh_host_ca`         | Plain text representation of the ssh host CA public key.                                        | `""`                                     |
+| `inject.certificates.ssh_user_ca`         | Plain text representation of the ssh user CA public key.                                        | `""`                                     |
+| `inject.secrets.enabled`                  | When true, secrets are injected into a Kubernetes Secret.                                       | `false`                                  |
+| `inject.secrets.ca_password`              | Base64 encoded string.  Password used to encrypt intermediate and ssh keys.                     | `""`                                     |
+| `inject.secrets.x509.intermediate_ca_key` | Plain text PEM representation of the intermediate CA private key.                               | `""`                                     |
+| `inject.secrets.x509.root_ca_key`         | Plain text PEM representation of the root CA private key.                                       | `""`                                     |
+| `inject.secrets.ssh.host_ca_key `         | Plain text representation of the ssh host CA private key.                                       | `""`                                     |
+| `inject.secrets.ssh.user_ca_key `         | Plain text representation of the ssh user CA private key.                                       | `""`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -85,18 +85,17 @@ chart and their default values.
 | `nodeSelector`                | Node labels for pod assignment (YAML)                                                                       | `{}`                                     |
 | `tolerations`                 | Toleration labels for pod assignment (YAML)                                                                 | `[]`                                     |
 | `affinity`                    | Affinity settings for pod assignment (YAML)                                                                 | `{}`                                     |
-| `inject.config.enabled`       | When true, configuration files and templates are injected into a Kubernetes configmap.                      | `false`                                  |
+| `inject.enabled`              | When true, configuration files and templates are injected into a Kubernetes objects and bootstrap capability is disabled.                      | `false`                                  |
 | `inject.config.files.ca.json` | Yaml representation of the step-ca ca.json file.  This map object is converted to its equivalent json representation before being injected into a configMap.  See the step-ca [documentation](https://smallstep.com/docs/step-ca/configuration). | See [values.yaml](./values.yaml) |
 | `inject.config.files.default.json` | Yaml representation of the step-cli defaults.json file.  This map object is converted to its equivalent json representation before being injected into a configMap.  See the step-cli [documentation](https://smallstep.com/docs/step-cli/reference). | See [values.yaml](./values.yaml) |
 | `inject.config.templates.x509_leaf.tpl`   | Example X509 Leaf Certifixate Template to inject into the configMap.                            | See [values.yaml](./values.yaml)         |
 | `inject.config.templates.ssh.tpl`         | Example SSH Certificate Template to inject into the configMap.                                  | See [values.yaml](./values.yaml)         |
-| `inject.certificates.enabled`             | When true, certificates are injected into a configmap.                                          | `false`                                  |
 | `inject.certificates.intermediate_ca`     | Plain text PEM representation of the intermediate CA certificate.                               | `""`                                     |
 | `inject.certificates.root_ca`             | Plain text PEM representation of the root CA certificate.                                       | `""`                                     |
 | `inject.certificates.ssh_host_ca`         | Plain text representation of the ssh host CA public key.                                        | `""`                                     |
 | `inject.certificates.ssh_user_ca`         | Plain text representation of the ssh user CA public key.                                        | `""`                                     |
-| `inject.secrets.enabled`                  | When true, secrets are injected into a Kubernetes Secret.                                       | `false`                                  |
-| `inject.secrets.ca_password`              | Base64 encoded string.  Password used to encrypt intermediate and ssh keys.                     | `""`                                     |
+| `inject.secrets.ca_password`              | Base64 encoded string.  Password used to encrypt intermediate and ssh keys.                     | `Cg==`                                     |
+| `inject.secrets.provisioner_password`     | Base64 encoded string.  Password used to encrypt JWK provisioner.                     | `Cg==`                                     |
 | `inject.secrets.x509.intermediate_ca_key` | Plain text PEM representation of the intermediate CA private key.                               | `""`                                     |
 | `inject.secrets.x509.root_ca_key`         | Plain text PEM representation of the root CA private key.                                       | `""`                                     |
 | `inject.secrets.ssh.host_ca_key `         | Plain text representation of the ssh host CA private key.                                       | `""`                                     |

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -67,6 +67,7 @@ chart and their default values.
 | `service.targetPort`          | Internal port where Step CA runs                                                                            | `9000`                                   |
 | `replicaCount`                | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
 | `image.repository`            | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
+| `image.initContainerRepository`            | Repository of the Step CA Init Container image                                                                             | `busybox:latest`           |
 | `image.tag`                   | Tag of the Step CA image                                                                                    | `latest`                                 |
 | `image.pullPolicy`            | Step CA image pull policy                                                                                   | `IfNotPresent`                           |
 | `bootstrap.image.repository`  | Repository of the Step CA bootstrap image                                                                   | `cr.step.sm/smallstep/step-ca-bootstrap` |

--- a/step-certificates/templates/bootstrap.yaml
+++ b/step-certificates/templates/bootstrap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Release.IsInstall .Values.bootstrap.enabled -}}
+{{- if .Release.IsInstall -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 ---
+{{- if and .Values.bootstrap.enabled (not .Values.inject.enabled) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -36,4 +37,5 @@ spec:
           - name: bootstrap
             mountPath: /home/step/bootstrap
             readOnly: true
+{{- end }}
 {{- end }}

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -94,15 +94,22 @@ spec:
       - name: config
         configMap:
           name: {{ include "step-certificates.fullname" . }}-config
+      {{- if not .Values.inject.secrets.enabled }}
       - name: secrets
         configMap:
           name: {{ include "step-certificates.fullname" . }}-secrets
+      {{- end }}
       - name: ca-password
         secret:
           secretName: {{ include "step-certificates.fullname" . }}-ca-password
       {{- if and .Values.ca.db.enabled (not .Values.ca.db.persistent) }}
       - name: database
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.inject.secrets.enabled }}
+      - name: secrets
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-secrets
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -1,13 +1,12 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: {{ .Values.kind }}
 metadata:
   name: {{ include "step-certificates.fullname" . }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 spec:
   # Only one replica is supported at this moment
-  # Requested {{ .Values.replicaCount }}
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "step-certificates.name" . }}
@@ -94,8 +93,11 @@ spec:
       - name: config
         configMap:
           name: {{ include "step-certificates.fullname" . }}-config
-      {{- if not .Values.inject.secrets.enabled }}
       - name: secrets
+      {{- if .Values.inject.enabled }}
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-secrets
+      {{- else }}
         configMap:
           name: {{ include "step-certificates.fullname" . }}-secrets
       {{- end }}
@@ -105,11 +107,6 @@ spec:
       {{- if and .Values.ca.db.enabled (not .Values.ca.db.persistent) }}
       - name: database
         emptyDir: {}
-      {{- end }}
-      {{- if .Values.inject.secrets.enabled }}
-      - name: secrets
-        secret:
-          secretName: {{ include "step-certificates.fullname" . }}-secrets
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "step-certificates.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- if .Release.IsInstall }}
+      {{- if and .Release.IsInstall (not .Values.inject.enabled) }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           image: {{ .Values.image.initContainerRepository }}

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -21,7 +21,7 @@ spec:
       {{- if .Release.IsInstall }}
       initContainers:
         - name: {{ .Chart.Name }}-init
-          image: busybox:latest
+          image: {{ .Values.image.initContainerRepository }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sleep", "20"]
       {{- end }}

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -147,3 +147,39 @@ data:
     echo "CA Fingerprint: $(step certificate fingerprint $(step path)/certs/root_ca.crt)"
     echo
 {{- end }}
+---
+{{- if .Values.inject.config.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
+data:
+  {{- range $key, $val := .Values.inject.config.files }}
+  {{ $key }}: |
+    {{- $val | toPrettyJson | nindent 4 }}
+  {{- end }}
+  {{- range $key, $val := .Values.inject.config.templates }}
+  {{ $key }}: |
+    {{- $val | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.inject.certificates.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
+data:
+  intermediate_ca.crt: |-
+    {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}
+  root_ca.crt: |-
+    {{- .Values.inject.certificates.root_ca | nindent 4 }}
+  ssh_host_ca_key.pub: {{ .Values.inject.certificates.ssh_host_ca }}
+  ssh_user_ca_key.pub:  {{ .Values.inject.certificates.ssh_host_ca }}
+{{- end }}

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.bootstrap.configmaps }}
 # ConfigMaps that will be updated by the configuration job: 
 # 1. Step CA config directory.
 # 2. Step CA certs direcotry.
 # 3. Step CA secrets directory.
+{{- if or .Values.bootstrap.configmaps .Values.inject.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,7 +10,20 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
+{{- if .Values.inject.enabled }}
+data:
+  {{- range $key, $val := .Values.inject.config.files }}
+  {{ $key }}: |
+    {{- $val | toPrettyJson | nindent 4 }}
+  {{- end }}
+  {{- range $key, $val := .Values.inject.config.templates }}
+  {{ $key }}: |
+    {{- $val | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
 ---
+{{- if or .Values.bootstrap.configmaps .Values.inject.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,7 +31,18 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
+{{- if .Values.inject.enabled }}
+data:
+  intermediate_ca.crt: |-
+    {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}
+  root_ca.crt: |-
+    {{- .Values.inject.certificates.root_ca | nindent 4 }}
+  ssh_host_ca_key.pub: {{ .Values.inject.certificates.ssh_host_ca }}
+  ssh_user_ca_key.pub:  {{ .Values.inject.certificates.ssh_host_ca }}
+{{- end }}
+{{- end }}
 ---
+{{- if and .Values.bootstrap.configmaps (not .Values.inject.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,7 +50,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
+{{- end }}
 ---
+{{- if and .Values.bootstrap.configmaps (not .Values.inject.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -146,40 +172,4 @@ data:
     echo "CA URL: {{include "step-certificates.url" .}}"
     echo "CA Fingerprint: $(step certificate fingerprint $(step path)/certs/root_ca.crt)"
     echo
-{{- end }}
----
-{{- if .Values.inject.config.enabled }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "step-certificates.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "step-certificates.labels" . | nindent 4 }}
-data:
-  {{- range $key, $val := .Values.inject.config.files }}
-  {{ $key }}: |
-    {{- $val | toPrettyJson | nindent 4 }}
-  {{- end }}
-  {{- range $key, $val := .Values.inject.config.templates }}
-  {{ $key }}: |
-    {{- $val | nindent 4 }}
-  {{- end }}
-{{- end }}
----
-{{- if .Values.inject.certificates.enabled }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "step-certificates.fullname" . }}-certs
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "step-certificates.labels" . | nindent 4 }}
-data:
-  intermediate_ca.crt: |-
-    {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}
-  root_ca.crt: |-
-    {{- .Values.inject.certificates.root_ca | nindent 4 }}
-  ssh_host_ca_key.pub: {{ .Values.inject.certificates.ssh_host_ca }}
-  ssh_user_ca_key.pub:  {{ .Values.inject.certificates.ssh_host_ca }}
 {{- end }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -1,33 +1,37 @@
-{{- if .Values.bootstrap.secrets }}
 # Secrets that will be updated by the configuration job: 
 # 1. CA keys password.
 # 2. Provisioner password.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "step-certificates.fullname" . }}-ca-password
-  namespace: {{ .Release.Namespace }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "step-certificates.fullname" . }}-provisioner-password
-  namespace: {{ .Release.Namespace }}
-{{- end }}
----
-{{- if .Values.inject.secrets.enabled }}
+
+{{- if or .Values.bootstrap.secrets .Values.inject.enabled }}
 apiVersion: v1
 kind: Secret
 type: smallstep.com/ca-password
 metadata:
   name: {{ include "step-certificates.fullname" . }}-ca-password
   namespace: {{ .Release.Namespace }}
+{{- if .Values.inject.enabled }}
 data:
   password: {{ .Values.inject.secrets.ca_password }}
+{{- end }}
+{{- end }}
 ---
+{{- if or .Values.bootstrap.secrets .Values.inject.enabled }}
 apiVersion: v1
 kind: Secret
-type: smallstep.com/private_keys
+type: smallstep.com/provisioner-password
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-provisioner-password
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.inject.enabled }}
+data:
+  password: {{ .Values.inject.secrets.provisioner_password }}
+{{- end }}
+{{- end }}
+---
+{{- if .Values.inject.enabled }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/private-keys
 metadata:
   name: {{ include "step-certificates.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -5,7 +5,9 @@
 {{- if or .Values.bootstrap.secrets .Values.inject.enabled }}
 apiVersion: v1
 kind: Secret
+{{- if .Values.inject.enabled }}
 type: smallstep.com/ca-password
+{{- end }}
 metadata:
   name: {{ include "step-certificates.fullname" . }}-ca-password
   namespace: {{ .Release.Namespace }}
@@ -18,7 +20,9 @@ data:
 {{- if or .Values.bootstrap.secrets .Values.inject.enabled }}
 apiVersion: v1
 kind: Secret
+{{- if .Values.inject.enabled }}
 type: smallstep.com/provisioner-password
+{{- end }}
 metadata:
   name: {{ include "step-certificates.fullname" . }}-provisioner-password
   namespace: {{ .Release.Namespace }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -14,3 +14,30 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-provisioner-password
   namespace: {{ .Release.Namespace }}
 {{- end }}
+---
+{{- if .Values.inject.secrets.enabled }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/ca-password
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-ca-password
+  namespace: {{ .Release.Namespace }}
+data:
+  password: {{ .Values.inject.secrets.ca_password }}
+---
+apiVersion: v1
+kind: Secret
+type: smallstep.com/private_keys
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+stringData:
+  intermediate_ca_key: |-
+    {{- .Values.inject.secrets.x509.intermediate_ca_key  | nindent 4 }}
+  root_ca_key: |-
+    {{- .Values.inject.secrets.x509.root_ca_key | nindent 4 }}
+  ssh_host_ca_key: |-
+    {{- .Values.inject.secrets.ssh.host_ca_key | nindent 4 }}
+  ssh_user_ca_key: |-
+    {{- .Values.inject.secrets.ssh.user_ca_key | nindent 4 }}
+{{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -16,6 +16,7 @@ fullnameOverride: ""
 # image contains the docker image for step-certificates.
 image:
   repository: cr.step.sm/smallstep/step-ca
+  initContainerRepository: busybox:latest
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -154,14 +154,14 @@ inject:
     ssh:
       # ssh_host_ca_key contains the contents of your encrypted SSH Host CA key
       host_ca_key: ""
-      # ssh_host_ca_key: |
+      # host_ca_key: |
       #   -----BEGIN OPENSSH PRIVATE KEY-----
       #   ...
       #   -----END OPENSSH PRIVATE KEY-----
 
       # ssh_user_ca_key contains the contents of your encrypted SSH User CA key
       user_ca_key: ""
-      # ssh_user_ca_key: |
+      # user_ca_key: |
       #   -----BEGIN OPENSSH PRIVATE KEY-----
       #   ...
       #   -----END OPENSSH PRIVATE KEY-----

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -1,5 +1,9 @@
 # Default values for step-certificates.
 
+# kind is the type of object to use when deploying the CA.
+# Changing the deployment type is experimental.
+kind: StatefulSet
+
 # replicaCount is the number of replicas of step-certificates.
 # Only one replica is supported at this time.
 replicaCount: 1
@@ -33,8 +37,8 @@ bootstrap:
 
 # inject contains values to be injected into config maps and secrets
 inject:
+  enabled: false
   config:
-    enabled: false
     files:
       ca.json:
         root: /home/step/certs/root_ca.crt
@@ -100,8 +104,6 @@ inject:
         }
 
   certificates:
-    enabled: false
-
     # intermediate_ca contains the text of the intermediate CA Certificate
     intermediate_ca: ""
     # intermediate_ca: |
@@ -125,12 +127,10 @@ inject:
     # ssh_user_ca: "ecdsa-sha2-nistp384 public-key-here=="
 
   secrets:
-    # enabled tells the helmchart to inject these values as secrets.
-    enabled: false
-
     # ca_password contains the password used to encrypt x509.intermediate_ca_key, ssh.host_ca_key and ssh.user_ca_key
     # This value must be base64 encoded.
-    ca_password: ""
+    ca_password: Cg==
+    provisioner_password: Cg==
 
     x509:
       # intermediate_ca_key contains the contents of your encrypted intermediate CA key

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -31,6 +31,141 @@ bootstrap:
   # secrets defines if the secrets are created.
   secrets: true
 
+# inject contains values to be injected into config maps and secrets
+inject:
+  config:
+    enabled: false
+    files:
+      ca.json:
+        root: /home/step/certs/root_ca.crt
+        federateRoots: []
+        crt: /home/step/certs/intermediate_ca.crt
+        key: /home/step/secrets/intermediate_ca_key
+        address: 0.0.0.0:9000
+        dnsNames:
+          - ca.example.com
+          - mysteprelease-step-certificates.default.svc.cluster.local
+          - 127.0.0.1
+        logger:
+          format: json
+        authority:
+          claims:
+            minTLSCertDuration: 5m
+            maxTLSCertDuration: 24h
+            defaultTLSCertDuration: 24h
+            disableRenewal: false
+            minHostSSHCertDuration: 5m
+            maxHostSSHCertDuration: 1680h
+            defaultHostSSHCertDuration: 720h
+            minUserSSHCertDuration: 5m
+            maxUserSSHCertDuration: 24h
+            defaultUserSSHCertDuration: 24h
+          provisioners:
+            - type: ACME
+              name: acme
+              forceCN: true
+              claims: {}
+        tls:
+          cipherSuites:
+            - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+            - TLS_AES_128_GCM_SHA256
+          minVersion: 1.2
+          maxVersion: 1.3
+          renegotiation: false
+      defaults.json:
+        ca-url: https://mysteprelease-step-certificates.default.svc.cluster.local
+        ca-config: /home/step/config/ca.json
+        fingerprint: fingerprint
+        root: /home/step/certs/root_ca.crt
+    templates:
+      x509_leaf.tpl: |
+        {
+          "subject": {{ toJson .Subject }},
+          "sans": {{ toJson .SANs }},
+        {{- if typeIs "*rsa.PublicKey" .Insecure.CR.PublicKey }}
+          "keyUsage": ["keyEncipherment", "digitalSignature"],
+        {{- else }}
+          "keyUsage": ["digitalSignature"],
+        {{- end }}
+          "extKeyUsage": ["serverAuth", "clientAuth"]
+        }
+      ssh.tpl: |
+        {
+          "type": {{ toJson .Type }},
+          "keyId": {{ toJson .KeyID }},
+          "principals": {{ toJson .Principals }},
+          "extensions": {{ toJson .Extensions }},
+          "criticalOptions": {{ toJson .CriticalOptions }}
+        }
+
+  certificates:
+    enabled: false
+
+    # intermediate_ca contains the text of the intermediate CA Certificate
+    intermediate_ca: ""
+    # intermediate_ca: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
+    # root_ca contains the text of the root CA Certificate
+    root_ca: ""
+    # root_ca: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
+    # ssh_host_ca contains the text of the public ssh key for the SSH root CA
+    ssh_host_ca: ""
+    # ssh_host_ca: "ecdsa-sha2-nistp384 public-key-here=="
+
+    # ssh_user_ca contains the text of the public ssh key for the SSH root CA
+    ssh_user_ca: ""
+    # ssh_user_ca: "ecdsa-sha2-nistp384 public-key-here=="
+
+  secrets:
+    # enabled tells the helmchart to inject these values as secrets.
+    enabled: false
+
+    # ca_password contains the password used to encrypt x509.intermediate_ca_key, ssh.host_ca_key and ssh.user_ca_key
+    # This value must be base64 encoded.
+    ca_password: ""
+
+    x509:
+      # intermediate_ca_key contains the contents of your encrypted intermediate CA key
+      intermediate_ca_key: ""
+      # intermediate_ca_key: |
+      #   -----BEGIN EC PRIVATE KEY-----
+      #   ...
+      #   -----END EC PRIVATE KEY-----
+
+      # root_ca_key contains the contents of your encrypted root CA key
+      # Note that this value can be omitted without impacting the functionality of step-certificates
+      # If supplied, this should be encrypted using a unique password that is not used for encrypting
+      # the intermediate_ca_key, ssh.host_ca_key or ssh.user_ca_key.
+      root_ca_key: ""
+      # root_ca_key: |
+      #   -----BEGIN EC PRIVATE KEY-----
+      #   ...
+      #   -----END EC PRIVATE KEY-----
+
+    ssh:
+      # ssh_host_ca_key contains the contents of your encrypted SSH Host CA key
+      host_ca_key: ""
+      # ssh_host_ca_key: |
+      #   -----BEGIN OPENSSH PRIVATE KEY-----
+      #   ...
+      #   -----END OPENSSH PRIVATE KEY-----
+
+      # ssh_user_ca_key contains the contents of your encrypted SSH User CA key
+      user_ca_key: ""
+      # ssh_user_ca_key: |
+      #   -----BEGIN OPENSSH PRIVATE KEY-----
+      #   ...
+      #   -----END OPENSSH PRIVATE KEY-----
+
+
 # service contains configuration for the kubernetes service.
 service:
   type: ClusterIP


### PR DESCRIPTION
Add ability to inject secrets, config & templates.
- Enables users to inject:
  - secrets
  - certificates
  - configuration
  - templates

- Enables users to configure all capabilities of
  step-certificates using only the helm chart.

- Enables users to use the native yaml to configure
  ca.json and have helm automatically translate it
  to json.

Related Issues:
- #45
- #2
- #9
- #22 
- #33 