### PR TITLE
configmaps to secrets, missing db config in inject block and ingress example structure.

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.15.17
+version: 1.15.18
 appVersion: 0.15.15
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -86,10 +86,15 @@ spec:
             mountPath: /home/step/db
             readOnly: false
           {{- end }}
-      volumes:
+      volumes: 
       - name: certs
+      {{- if .Values.inject.enabled }}           
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-certs
+      {{- else }}              
         configMap:
           name: {{ include "step-certificates.fullname" . }}-certs
+      {{- end }}          
       - name: config
         configMap:
           name: {{ include "step-certificates.fullname" . }}-config

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -23,7 +23,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if or .Values.bootstrap.configmaps .Values.inject.enabled }}
+{{- if and .Values.bootstrap.configmaps (not .Values.inject.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,15 +31,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
-{{- if .Values.inject.enabled }}
-data:
-  intermediate_ca.crt: |-
-    {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}
-  root_ca.crt: |-
-    {{- .Values.inject.certificates.root_ca | nindent 4 }}
-  ssh_host_ca_key.pub: {{ .Values.inject.certificates.ssh_host_ca }}
-  ssh_user_ca_key.pub:  {{ .Values.inject.certificates.ssh_user_ca }}
-{{- end }}
 {{- end }}
 ---
 {{- if and .Values.bootstrap.configmaps (not .Values.inject.enabled) }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -39,13 +39,23 @@ type: smallstep.com/private-keys
 metadata:
   name: {{ include "step-certificates.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
-stringData:
-  intermediate_ca_key: |-
-    {{- .Values.inject.secrets.x509.intermediate_ca_key  | nindent 4 }}
-  root_ca_key: |-
-    {{- .Values.inject.secrets.x509.root_ca_key | nindent 4 }}
-  ssh_host_ca_key: |-
-    {{- .Values.inject.secrets.ssh.host_ca_key | nindent 4 }}
-  ssh_user_ca_key: |-
-    {{- .Values.inject.secrets.ssh.user_ca_key | nindent 4 }}
+data:
+  intermediate_ca_key: {{ .Values.inject.secrets.x509.intermediate_ca_key }}
+  root_ca_key: {{ .Values.inject.secrets.x509.root_ca_key }}
+  ssh_host_ca_key: {{ .Values.inject.secrets.ssh.host_ca_key }}
+  ssh_user_ca_key: {{ .Values.inject.secrets.ssh.user_ca_key }}
+{{- end }}
+---
+{{- if .Values.inject.enabled }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/certs
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
+data:
+  intermediate_ca.crt: {{ .Values.inject.certificates.intermediate_ca }}
+  root_ca.crt: {{ .Values.inject.certificates.root_ca }}
+  ssh_host_ca.pub: {{ .Values.inject.certificates.ssh_host_ca }}
+  ssh_user_ca.pub: {{ .Values.inject.certificates.ssh_user_ca }}
 {{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -78,6 +78,10 @@ inject:
           minVersion: 1.2
           maxVersion: 1.3
           renegotiation: false
+        db:
+          type: "badger"
+          dataSource: "/home/step/db"
+          badgerFileLoadingMode: "MemoryMap"          
       defaults.json:
         ca-url: https://mysteprelease-step-certificates.default.svc.cluster.local
         ca-config: /home/step/config/ca.json
@@ -106,26 +110,20 @@ inject:
 
   certificates:
     # intermediate_ca contains the text of the intermediate CA Certificate
+    # This value must be base64 encoded.
     intermediate_ca: ""
-    # intermediate_ca: |
-    #   -----BEGIN CERTIFICATE-----
-    #   ...
-    #   -----END CERTIFICATE-----
 
     # root_ca contains the text of the root CA Certificate
+    # This value must be base64 encoded.
     root_ca: ""
-    # root_ca: |
-    #   -----BEGIN CERTIFICATE-----
-    #   ...
-    #   -----END CERTIFICATE-----
 
     # ssh_host_ca contains the text of the public ssh key for the SSH root CA
+    # This value must be base64 encoded.
     ssh_host_ca: ""
-    # ssh_host_ca: "ecdsa-sha2-nistp384 public-key-here=="
 
     # ssh_user_ca contains the text of the public ssh key for the SSH root CA
+    # This value must be base64 encoded.
     ssh_user_ca: ""
-    # ssh_user_ca: "ecdsa-sha2-nistp384 public-key-here=="
 
   secrets:
     # ca_password contains the password used to encrypt x509.intermediate_ca_key, ssh.host_ca_key and ssh.user_ca_key
@@ -135,36 +133,24 @@ inject:
 
     x509:
       # intermediate_ca_key contains the contents of your encrypted intermediate CA key
+      # This value must be base64 encoded.
       intermediate_ca_key: ""
-      # intermediate_ca_key: |
-      #   -----BEGIN EC PRIVATE KEY-----
-      #   ...
-      #   -----END EC PRIVATE KEY-----
 
       # root_ca_key contains the contents of your encrypted root CA key
       # Note that this value can be omitted without impacting the functionality of step-certificates
       # If supplied, this should be encrypted using a unique password that is not used for encrypting
       # the intermediate_ca_key, ssh.host_ca_key or ssh.user_ca_key.
+      # This value must be base64 encoded.
       root_ca_key: ""
-      # root_ca_key: |
-      #   -----BEGIN EC PRIVATE KEY-----
-      #   ...
-      #   -----END EC PRIVATE KEY-----
 
     ssh:
       # ssh_host_ca_key contains the contents of your encrypted SSH Host CA key
+      # This value must be base64 encoded.
       host_ca_key: ""
-      # host_ca_key: |
-      #   -----BEGIN OPENSSH PRIVATE KEY-----
-      #   ...
-      #   -----END OPENSSH PRIVATE KEY-----
 
       # ssh_user_ca_key contains the contents of your encrypted SSH User CA key
+      # This value must be base64 encoded.
       user_ca_key: ""
-      # user_ca_key: |
-      #   -----BEGIN OPENSSH PRIVATE KEY-----
-      #   ...
-      #   -----END OPENSSH PRIVATE KEY-----
 
 
 # service contains configuration for the kubernetes service.
@@ -231,6 +217,9 @@ ingress:
   enabled: false
   annotations: {}
   hosts: []
+    # - host: ca.example.com
+    #   paths:
+    #     - /  
   tls: []
 
 # resources contains the CPU/memory resource requests/limits.


### PR DESCRIPTION
Hope this changes can be useful:
- Changed configmaps to secrets at inject block, so in values.yaml they must be added as base64.
- Added missing configuration in values.yaml in the **inject** block. Lines from 81-84. Without this default db config it won't work because of a http panic server bug.
- At the end of values.yaml, added an ingress example structure. Lines from 220-222.