### PR TITLE
Add registration authority support

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.16.0
+version: 1.16.1
 appVersion: 0.16.0
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -8,7 +8,8 @@ To learn more, visit <https://github.com/smallstep/certificates>.
 ## TL;DR
 
 ```console
-helm install step-certificates
+helm repo add smallstep https://smallstep.github.io/helm-charts/
+helm install smallstep/step-certificates
 ```
 
 ## Prerequisites

--- a/step-certificates/examples/README.md
+++ b/step-certificates/examples/README.md
@@ -1,0 +1,39 @@
+# Helm Configuration Examples
+
+## Registration Authority Connected to Smallstep Certificate Manager Hosted Certificate Authority.
+
+```bash
+CA_NAME='example-ca'
+CA_FINGERPRINT='ca-fingerprint'
+ORG_NAME='example-org'
+
+# Install Step If Not already installed.
+brew install step
+
+# Bootstrap Step against the CA if not already bootstrapped.
+step ca bootstrap --ca-url https://${CA_NAME}.${ORG_NAME}.ca.smallstep.com --fingerprint ${CA_FINGERPRINT}
+
+# Create a registration-authority JWK Provisioner
+step beta ca provisioner add registration-authority --create
+
+# Encode the JWK Provisioner password in base64
+JWK_ISSUER_PASSWORD=`echo 'your-password-here' | base64`
+
+# Download the example values.yml
+curl -o step_values.yml https://raw.githubusercontent.com/smallstep/helm-charts/master/step-certificates/examples/registration_authority/values.yml
+
+# Replace dummy values with your own values
+sed -e "s/your-ca-name/${CA_NAME}/g" -i step_values.yml
+sed -e "s/your-org/${ORG_NAME}/g" -i step_values.yml
+sed -e "s/your-ca-fingerprint-here/${CA_FINGERPRINT}/g" -i step_values.yml
+sed -e "s/your-base-64-encoded-key-password/${JWK_ISSUER_PASSWORD}/g" -i step_values.yml
+
+# Add the smallstep helm repo, if not already added
+helm repo add smallstep https://smallstep.github.io/helm-charts/
+
+# Update helm repos to ensure you have the latest version
+helm repo update smallstep
+
+# Install the step-certificates helm chart.
+helm install -f step_values.yml smallstep/step-certificates
+```

--- a/step-certificates/examples/registration_authority/values.yml
+++ b/step-certificates/examples/registration_authority/values.yml
@@ -28,9 +28,6 @@ inject:
               type: ACME
           type: stepcas
         crt: ''
-        db:
-          dataSource: /home/step/db
-          type: badger
         dnsNames:
           - your-local-dns.your-internal-zone.com
           - step-step-certificates.your-k8s-namespace.svc.cluster.local

--- a/step-certificates/examples/registration_authority/values.yml
+++ b/step-certificates/examples/registration_authority/values.yml
@@ -7,11 +7,6 @@ ca:
       enabled: true
       persistent: false
 inject:
-  certificates:
-    root_ca: |-
-      -----BEGIN CERTIFICATE-----
-      your pem encoded root ca certificate here
-      -----END CERTIFICATE-----
   config:
     files:
       ca.json:
@@ -43,7 +38,6 @@ inject:
         ca-url: https:/your-ca-name.your-org.ca.smallstep.com
         fingerprint: your-ca-fingerprint-here
         redirect-url: ''
-        root: /home/step/certs/root_ca.crt
     enabled: true
     secrets:
       certificate_issuer:

--- a/step-certificates/examples/registration_authority/values.yml
+++ b/step-certificates/examples/registration_authority/values.yml
@@ -35,7 +35,7 @@ inject:
           minVersion: 1.2
           renegotiation: false
       defaults.json:
-        ca-url: https:/your-ca-name.your-org.ca.smallstep.com
+        ca-url: https://your-ca-name.your-org.ca.smallstep.com
         fingerprint: your-ca-fingerprint-here
         redirect-url: ''
     enabled: true

--- a/step-certificates/examples/registration_authority/values.yml
+++ b/step-certificates/examples/registration_authority/values.yml
@@ -1,0 +1,68 @@
+autocert:
+  enabled: false
+bootstrap:
+  enabled: false
+ca:
+  db:
+      enabled: true
+      persistent: false
+inject:
+  certificates:
+    root_ca: |-
+      -----BEGIN CERTIFICATE-----
+      your pem encoded root ca certificate here
+      -----END CERTIFICATE-----
+  config:
+    files:
+      ca.json:
+        address: :9100
+        authority:
+          certificateAuthority: https://your-ca-name.your-org.ca.smallstep.com
+          certificateAuthorityFingerprint: your-ca-fingerprint-here
+          certificateIssuer:
+            key: /home/step/secrets/certificate_issuer_key
+            provisioner: registration-authority
+            type: jwk
+          provisioners:
+            - name: acme
+              type: ACME
+          type: stepcas
+        crt: ''
+        db:
+          dataSource: /home/step/db
+          type: badger
+        dnsNames:
+          - your-local-dns.your-internal-zone.com
+          - step-step-certificates.your-k8s-namespace.svc.cluster.local
+        logger:
+            format: json
+        tls:
+          cipherSuites:
+          - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+          - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+          maxVersion: 1.3
+          minVersion: 1.2
+          renegotiation: false
+      defaults.json:
+        ca-url: https:/your-ca-name.your-org.ca.smallstep.com
+        fingerprint: your-ca-fingerprint-here
+        redirect-url: ''
+        root: /home/step/certs/root_ca.crt
+    enabled: true
+    secrets:
+      certificate_issuer:
+        enabled: true
+        key: |-
+          -----BEGIN ENCRYPTED PRIVATE KEY-----
+          your pem encoded encrypted provisioner key here
+          -----END ENCRYPTED PRIVATE KEY-----
+        password: your-base-64-encoded-key-password
+      ssh:
+        enabled: false
+      x509:
+        enabled: false
+service:
+  nodePort: 32400
+  port: 443
+  targetPort: 9100
+  type: NodePort

--- a/step-certificates/examples/registration_authority/values.yml
+++ b/step-certificates/examples/registration_authority/values.yml
@@ -20,7 +20,6 @@ inject:
           certificateAuthority: https://your-ca-name.your-org.ca.smallstep.com
           certificateAuthorityFingerprint: your-ca-fingerprint-here
           certificateIssuer:
-            key: /home/step/secrets/certificate_issuer_key
             provisioner: registration-authority
             type: jwk
           provisioners:
@@ -49,10 +48,6 @@ inject:
     secrets:
       certificate_issuer:
         enabled: true
-        key: |-
-          -----BEGIN ENCRYPTED PRIVATE KEY-----
-          your pem encoded encrypted provisioner key here
-          -----END ENCRYPTED PRIVATE KEY-----
         password: your-base-64-encoded-key-password
       ssh:
         enabled: false

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -40,7 +40,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [
             "/usr/local/bin/step-ca",
+            {{- if and .Values.inject.enabled (and .Values.inject.secrets.certificate_issuer.enabled (not (eq .Values.inject.secrets.certificate_issuer.password ""))) }}
+            "--issuer-password-file", "/home/step/secrets/certificate-issuer/password",
+            {{- end }}
+            {{- if or (and .Values.bootstrap.enabled .Values.bootstrap.secrets) (and .Values.inject.enabled (not (eq .Values.inject.secrets.ca_password ""))) }}
             "--password-file", "/home/step/secrets/passwords/password",
+            {{- end }}
             "/home/step/config/ca.json"
           ]
           env:
@@ -78,13 +83,20 @@ spec:
           - name: secrets
             mountPath: /home/step/secrets
             readOnly: true
+          {{- if or (and .Values.bootstrap.enabled .Values.bootstrap.secrets) (and .Values.inject.enabled (not (eq .Values.inject.secrets.ca_password ""))) }}
           - name: ca-password
             mountPath: /home/step/secrets/passwords
             readOnly: true
+          {{- end }}
           {{- if .Values.ca.db.enabled }}
           - name: database
             mountPath: /home/step/db
             readOnly: false
+          {{- end }}
+          {{- if and .Values.inject.enabled (and .Values.inject.secrets.certificate_issuer.enabled (not (eq .Values.inject.secrets.certificate_issuer.password ""))) }}
+          - name: certificate-issuer
+            mountPath: /home/step/secrets/certificate-issuer
+            readOnly: true
           {{- end }}
       volumes:
       - name: certs
@@ -101,9 +113,16 @@ spec:
         configMap:
           name: {{ include "step-certificates.fullname" . }}-secrets
       {{- end }}
+      {{- if or (and .Values.bootstrap.enabled .Values.bootstrap.secrets) (and .Values.inject.enabled (not (eq .Values.inject.secrets.ca_password ""))) }}
       - name: ca-password
         secret:
           secretName: {{ include "step-certificates.fullname" . }}-ca-password
+      {{- end }}
+      {{- if and .Values.inject.enabled (and .Values.inject.secrets.certificate_issuer.enabled (not (eq .Values.inject.secrets.certificate_issuer.password ""))) }}
+      - name: certificate-issuer
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-certificate-issuer-password
+      {{- end }}
       {{- if and .Values.ca.db.enabled (not .Values.ca.db.persistent) }}
       - name: database
         emptyDir: {}

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -11,7 +11,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "step-certificates.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if eq .Values.kind "StatefulSet" }}
   serviceName: {{ include "step-certificates.fullname" . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -33,12 +33,16 @@ metadata:
     {{- include "step-certificates.labels" . | nindent 4 }}
 {{- if .Values.inject.enabled }}
 data:
+  {{- if .Values.inject.secrets.x509.enabled }}
   intermediate_ca.crt: |-
     {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}
   root_ca.crt: |-
     {{- .Values.inject.certificates.root_ca | nindent 4 }}
+  {{- end }}
+  {{- if .Values.inject.secrets.ssh.enabled }}
   ssh_host_ca_key.pub: {{ .Values.inject.certificates.ssh_host_ca }}
   ssh_user_ca_key.pub:  {{ .Values.inject.certificates.ssh_user_ca }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -33,7 +33,7 @@ metadata:
     {{- include "step-certificates.labels" . | nindent 4 }}
 {{- if .Values.inject.enabled }}
 data:
-  {{- if and .Values.inject.secrets.certificate_issuer_key.enabled .Values.inject.certificates.certificate_issuer!="" }}
+  {{- if and .Values.inject.secrets.certificate_issuer_key.enabled (not (eq .Values.inject.certificates.certificate_issuer "")) }}
   certificate_issuer.crt: |-
     {{- .Values.inject.certificates.certificate_issuer }}
   {{- end }}

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -33,6 +33,10 @@ metadata:
     {{- include "step-certificates.labels" . | nindent 4 }}
 {{- if .Values.inject.enabled }}
 data:
+  {{- if and .Values.inject.secrets.certificate_issuer_key.enabled .Values.inject.certificates.certificate_issuer!="" }}
+  certificate_issuer.crt: |-
+    {{- .Values.inject.certificates.certificate_issuer }}
+  {{- end }}
   {{- if .Values.inject.secrets.x509.enabled }}
   intermediate_ca.crt: |-
     {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -33,13 +33,15 @@ metadata:
     {{- include "step-certificates.labels" . | nindent 4 }}
 {{- if .Values.inject.enabled }}
 data:
-  {{- if and .Values.inject.secrets.certificate_issuer_key.enabled (not (eq .Values.inject.certificates.certificate_issuer "")) }}
+  {{- if and .Values.inject.secrets.certificate_issuer.enabled (not (eq "" (.Values.inject.certificates.certificate_issuer | default "" ))) }}
   certificate_issuer.crt: |-
     {{- .Values.inject.certificates.certificate_issuer }}
   {{- end }}
-  {{- if .Values.inject.secrets.x509.enabled }}
+  {{- if not (eq "" (.Values.inject.certificates.intermediate_ca | default "" )) }}
   intermediate_ca.crt: |-
     {{- .Values.inject.certificates.intermediate_ca | nindent 4 }}
+  {{- end }}
+  {{- if not (eq "" (.Values.inject.certificates.root_ca | default "" )) }}
   root_ca.crt: |-
     {{- .Values.inject.certificates.root_ca | nindent 4 }}
   {{- end }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -2,7 +2,7 @@
 # 1. CA keys password.
 # 2. Provisioner password.
 
-{{- if or .Values.bootstrap.secrets .Values.inject.enabled }}
+{{- if or (and .Values.bootstrap.enabled .Values.bootstrap.secrets) (and .Values.inject.enabled (not (eq .Values.inject.secrets.ca_password ""))) }}
 apiVersion: v1
 kind: Secret
 {{- if .Values.inject.enabled }}
@@ -17,7 +17,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if or .Values.bootstrap.secrets .Values.inject.enabled }}
+{{- if or (and .Values.bootstrap.enabled .Values.bootstrap.secrets) (and .Values.inject.enabled (not (eq .Values.inject.secrets.provisioner_password ""))) }}
 apiVersion: v1
 kind: Secret
 {{- if .Values.inject.enabled }}
@@ -32,7 +32,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if and .Values.inject.enabled .Values.inject.secrets.certificate_issuer.enabled }}
+{{- if and .Values.inject.enabled (and .Values.inject.secrets.certificate_issuer.enabled (not (eq .Values.inject.secrets.certificate_issuer.password ""))) }}
 apiVersion: v1
 kind: Secret
 type: smallstep.com/certificate-issuer-password

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -32,7 +32,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if and .Values.inject.enabled .Values.inject.secrets.certificate_issuer_key.enabled }}
+{{- if and .Values.inject.enabled .Values.inject.secrets.certificate_issuer.enabled }}
 apiVersion: v1
 kind: Secret
 type: smallstep.com/certificate-issuer-password

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -40,12 +40,16 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
 stringData:
+  {{- if .Values.inject.secrets.x509.enabled }}
   intermediate_ca_key: |-
     {{- .Values.inject.secrets.x509.intermediate_ca_key  | nindent 4 }}
   root_ca_key: |-
     {{- .Values.inject.secrets.x509.root_ca_key | nindent 4 }}
+  {{- end }}
+  {{- if .Values.inject.secrets.ssh.enabled }}
   ssh_host_ca_key: |-
     {{- .Values.inject.secrets.ssh.host_ca_key | nindent 4 }}
   ssh_user_ca_key: |-
     {{- .Values.inject.secrets.ssh.user_ca_key | nindent 4 }}
+  {{- end}}
 {{- end }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -32,6 +32,17 @@ data:
 {{- end }}
 {{- end }}
 ---
+{{- if and .Values.inject.enabled .Values.inject.secrets.certificate_issuer_key.enabled }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/certificate-issuer-password
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-certificate-issuer-password
+  namespace: {{ .Release.Namespace }}
+data:
+  password: {{ .Values.inject.secrets.certificate_issuer.password }}
+{{- end }}
+---
 {{- if .Values.inject.enabled }}
 apiVersion: v1
 kind: Secret
@@ -40,6 +51,10 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
 stringData:
+  {{- if .Values.inject.secrets.certificate_issuer.enabled }}
+  certificate_issuer_key: |-
+    {{- .Values.inject.secrets.certificate_issuer.key | nindent 4 }}
+  {{- end }}
   {{- if .Values.inject.secrets.x509.enabled }}
   intermediate_ca_key: |-
     {{- .Values.inject.secrets.x509.intermediate_ca_key  | nindent 4 }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -51,7 +51,7 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
 stringData:
-  {{- if .Values.inject.secrets.certificate_issuer.enabled }}
+  {{- if and .Values.inject.secrets.certificate_issuer.enabled (not (eq .Values.inject.secrets.certificate_issuer.key "")) }}
   certificate_issuer_key: |-
     {{- .Values.inject.secrets.certificate_issuer.key | nindent 4 }}
   {{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -134,6 +134,8 @@ inject:
     provisioner_password: Cg==
 
     x509:
+      # enabled disables injection of x509 certificates and keys when set to false.
+      enabled: true
       # intermediate_ca_key contains the contents of your encrypted intermediate CA key
       intermediate_ca_key: ""
       # intermediate_ca_key: |
@@ -152,6 +154,8 @@ inject:
       #   -----END EC PRIVATE KEY-----
 
     ssh:
+      # enabled disables injection of ssh certificates and keys when set to false.
+      enabled: true
       # ssh_host_ca_key contains the contents of your encrypted SSH Host CA key
       host_ca_key: ""
       # host_ca_key: |

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -108,7 +108,7 @@ inject:
         }
 
   certificates:
-    # certificate_issuer_crt contains the text of the Certificate Issuer certificate in PEM format.
+    # certificate_issuer contains the text of the Certificate Issuer certificate in PEM format.
     # when set to "", certificate issuer crt is not injected, this is the default for the JWK provisioner.
     # Provide a value if using the X5C provisioner.
     certificate_issuer: ""

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -148,6 +148,7 @@ inject:
     certificate_issuer:
       # enabled enables injection of certificate issuer certificates and keys when set to true.
       enabled: false
+      key: ""
       # key: |
       #   -----BEGIN ENCRYPTED PRIVATE KEY-----
       #   ...

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -105,6 +105,15 @@ inject:
         }
 
   certificates:
+    # certificate_issuer_crt contains the text of the Certificate Issuer certificate in PEM format.
+    # when set to "", certificate issuer crt is not injected, this is the default for the JWK provisioner.
+    # Provide a value if using the X5C provisioner.
+    certificate_issuer_crt: ""
+    # certificate_issuer_crt: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
     # intermediate_ca contains the text of the intermediate CA Certificate
     intermediate_ca: ""
     # intermediate_ca: |
@@ -132,6 +141,16 @@ inject:
     # This value must be base64 encoded.
     ca_password: Cg==
     provisioner_password: Cg==
+    
+    certificate_issuer:
+      # enabled enables injection of certificate issuer certificates and keys when set to true.
+      enabled: false
+      # key: |
+      #   -----BEGIN ENCRYPTED PRIVATE KEY-----
+      #   ...
+      #   -----END ENCRYPTED PRIVATE KEY-----
+      # password sets the certificate issuer password that decrypts the encrypted certificate issuer key.  Must be base64 encoded.
+      # password: Cg==
 
     x509:
       # enabled enables injection of x509 certificates and keys when set to true.

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -134,7 +134,7 @@ inject:
     provisioner_password: Cg==
 
     x509:
-      # enabled disables injection of x509 certificates and keys when set to false.
+      # enabled enables injection of x509 certificates and keys when set to true.
       enabled: true
       # intermediate_ca_key contains the contents of your encrypted intermediate CA key
       intermediate_ca_key: ""
@@ -154,7 +154,7 @@ inject:
       #   -----END EC PRIVATE KEY-----
 
     ssh:
-      # enabled disables injection of ssh certificates and keys when set to false.
+      # enabled enables injection of ssh certificates and keys when set to true.
       enabled: true
       # ssh_host_ca_key contains the contents of your encrypted SSH Host CA key
       host_ca_key: ""

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -108,8 +108,8 @@ inject:
     # certificate_issuer_crt contains the text of the Certificate Issuer certificate in PEM format.
     # when set to "", certificate issuer crt is not injected, this is the default for the JWK provisioner.
     # Provide a value if using the X5C provisioner.
-    certificate_issuer_crt: ""
-    # certificate_issuer_crt: |
+    certificate_issuer: ""
+    # certificate_issuer: |
     #   -----BEGIN CERTIFICATE-----
     #   ...
     #   -----END CERTIFICATE-----
@@ -139,8 +139,8 @@ inject:
   secrets:
     # ca_password contains the password used to encrypt x509.intermediate_ca_key, ssh.host_ca_key and ssh.user_ca_key
     # This value must be base64 encoded.
-    ca_password: Cg==
-    provisioner_password: Cg==
+    ca_password: ""
+    provisioner_password: ""
     
     certificate_issuer:
       # enabled enables injection of certificate issuer certificates and keys when set to true.
@@ -150,7 +150,7 @@ inject:
       #   ...
       #   -----END ENCRYPTED PRIVATE KEY-----
       # password sets the certificate issuer password that decrypts the encrypted certificate issuer key.  Must be base64 encoded.
-      # password: Cg==
+      password: ""
 
     x509:
       # enabled enables injection of x509 certificates and keys when set to true.


### PR DESCRIPTION
This PR adds the following capabilities

- All public certificates are now optionally injectable
- Secrets are now optionally injectable
- CA and Provisioner passwords are now optionally injectable
- Adds ability to inject a Certificate Issuer password
- Adds ability to configure and inject both JWK and X5C Registration Authority Credentials
- Enables deployment as a `Deployment` object.
- Adds documentation for adding helm repo

Addresses the following issues:
#1 
#52 
#61 