### PR TITLE
add service account for step-issuer

### DIFF
--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "step-issuer.serviceAccountName" . }}
+      {{- end }}
       containers:
       - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
         name: kube-rbac-proxy

--- a/step-issuer/templates/rbac/clusterRoleBinding.yaml
+++ b/step-issuer/templates/rbac/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ roleRef:
   name: "{{ template "step-issuer.fullname" . }}-manager-role"
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "step-issuer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,7 +22,7 @@ roleRef:
   name: "{{ template "step-issuer.fullname" . }}-proxy-role"
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "step-issuer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/step-issuer/templates/rbac/roleBinding.yaml
+++ b/step-issuer/templates/rbac/roleBinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: "{{ template "step-issuer.fullname" . }}-leader-election-role"
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "step-issuer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/step-issuer/templates/rbac/sa.yaml
+++ b/step-issuer/templates/rbac/sa.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "step-issuer.serviceAccountName" . }}
+  labels:
+    {{- include "step-issuer.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -36,6 +36,15 @@ service:
   controlPlane: controller-manager
   scrape: true
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 # mandatory values to generate stepIssuer resource
 # please follow the https://github.com/smallstep/step-issuer#getting-started to setup step-ca and get step-issuer values
 stepIssuer:


### PR DESCRIPTION
`step-issuer` uses the default ServiceAccount of the namespace where it's installed. However, in some [hardened environments](https://rancher.com/docs/rancher/v2.x/en/security/rancher-2.4/hardening-2.4/#set-automountserviceaccounttoken-to-false-for-default-service-accounts) the default service account may not have the token mounted, as it will have disabled `automountServiceAccountToken`. Where this is the case, the `kube-rbac-proxy` won't be able to start as it needs a ServiceAccount that can be authenticated

This PR adds a service account in the same way in the same way in which `helm create` generates for new charts