### PR TITLE
Bump gcr.io/kubebuilder/kube-rbac-proxy

### DIFF
--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
-      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         args: ["--secure-listen-address=0.0.0.0:8443", "--upstream=http://127.0.0.1:8080/", "--logtostderr=true", "--v=10"]
         ports:


### PR DESCRIPTION
Bump gcr.io/kubebuilder/kube-rbac-proxy to 0.8.0 to address security concerns, as per the docs of [kubebuilder](https://book.kubebuilder.io/migration/v2vsv3.html#kubebuilder)