### PR TITLE
Add support for linked ca

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: step-certificates
-version: 1.16.1
-appVersion: 0.16.0
+version: 1.17.0
+appVersion: 0.17.0
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:
  - acme

--- a/step-certificates/templates/_helpers.tpl
+++ b/step-certificates/templates/_helpers.tpl
@@ -65,3 +65,22 @@ Create CA DNS
 {{- printf "%s.%s.svc.cluster.local,127.0.0.1" (include "step-certificates.fullname" .) .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Linked CA variables
+*/}}
+{{- define "step-certificates.linkedca.secretKeyRef.name" -}}
+{{- if .Values.linkedca.secretKeyRef.name -}}
+{{- .Values.linkedca.secretKeyRef.name -}}
+{{- else -}}
+{{- printf "%s-step-ca-token" (include "step-certificates.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "step-certificates.linkedca.secretKeyRef.key" -}}
+{{- if .Values.linkedca.secretKeyRef.key -}}
+{{- .Values.linkedca.secretKeyRef.key -}}
+{{- else -}}
+token
+{{- end -}}
+{{- end -}}

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -53,6 +53,13 @@ spec:
           env:
           - name: NAMESPACE
             value: "{{ .Release.Namespace }}"
+          {{- if or .Values.linkedca.token (and .Values.linkedca.secretKeyRef.name .Values.linkedca.secretKeyRef.key) }}
+          - name: STEP_CA_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "step-certificates.linkedca.secretKeyRef.name" . }}
+                key: {{ include "step-certificates.linkedca.secretKeyRef.key" . }}
+          {{- end }}
           ports:
             - name: https
               containerPort: {{ .Values.service.targetPort }}

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -68,3 +68,14 @@ stringData:
     {{- .Values.inject.secrets.ssh.user_ca_key | nindent 4 }}
   {{- end}}
 {{- end }}
+---
+{{- if .Values.linkedca.token }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/step-ca-token
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-step-ca-token
+  namespace: {{ .Release.Namespace }}
+data:
+  token: {{ .Values.linkedca.token }}
+{{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -193,13 +193,24 @@ inject:
       #   ...
       #   -----END OPENSSH PRIVATE KEY-----
 
-
 # service contains configuration for the kubernetes service.
 service:
   type: ClusterIP
   port: 443
   targetPort: 9000
   nodePort: ""
+
+# linkedca contains the token to configure step-ca using the linkedca mode.
+#
+# The linked ca token can be provided using the linkedca.token value or using a
+# reference to a secret.
+linkedca:
+  # the linked ca token.
+  token:
+  # Reference to a secret name and key.
+  secretKeyRef:
+    name:
+    key:
 
 # ca contains the certificate authority configuration.
 ca:


### PR DESCRIPTION
### Description

This PR adds support to start the step-certificates helm chart with Linked CA support.

Future releases will remove the automatic bootstrap of the PKI, and will require the use of `step ca init --helm`.

This PR requires the release of `step` and `step-ca` v0.17.0