### PR TITLE
Add ssh cert password secrets

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.17.2
+version: 1.17.3
 appVersion: 0.17.2
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/examples/README.md
+++ b/step-certificates/examples/README.md
@@ -2,78 +2,43 @@
 
 ## Self Hosted Single Instance Certificate Authority
 
+1. Edit `./certificate_authority_single_instance/ca.config` to reflect your CA environment.
+
+```json
+{
+  "root_ca_name": "example-root-ca",
+  "intermediate_ca_name": "example-intermediate-ca",
+  "ca_org_name": "Example CA Org",
+  "ca_country_name": "US",
+  "ca_locality_name": "Minnesota",
+  "ca_dns_names": [
+    "ca.example.com",
+    "mysteprelease-step-certificates.default.svc.cluster.local",
+    "127.0.0.1"
+  ]
+}
+```
+
+2. Run the following bash script
+
 ```bash
-ROOT_CA_NAME='example-root-ca'
-INTERMEDIATE_CA_NAME='example-intermediate-ca'
-CA_ORG_NAME='Example CA Org'
-CA_COUNTRY_NAME='US'
-CA_LOCALITY_NAME='Minnesota'
-export ROOT_CA_NAME INTERMEDIATE_CA_NAME CA_ORG_NAME CA_COUNTRY_NAME CA_LOCALITY_NAME
+# Navigate to the example directory.
+cd ./certificate_authority_single_instance
 
-# Write Out Root and Intermediate Certificate Templates
-cat root-tls.json.tpl | envsubst | tee root-tls.json
-cat intermediate-tls.json.tpl | envsubst | tee intermediate-tls.json
+# Generate key material and inject into values.yaml
+./generate-values.sh
 
-# Generate Root and Intermediate Passwords
-ROOT_TLS_PASSWORD_B64=`tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_\`{|}~' </dev/urandom | head -c 64 | tee root-tls.password | base64 --wrap=0`
-INTERMEDIATE_TLS_PASSWORD_B64=`tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_\`{|}~' </dev/urandom | head -c 64 | tee intermediate-tls.password | base64 --wrap=0`
+# Add the smallstep helm repo, if not already added
+helm repo add smallstep https://smallstep.github.io/helm-charts/
 
-# Generate Root CA Certificate Pair
-step certificate create \
-  "${ROOT_CA_NAME}" \
-  "root-tls.crt" \
-  "root-tls.key" \
-  --template="root-tls.json" \
-  --kty="EC" \
-  --curve="P-256" \
-  --password-file="root-tls.password" \
-  --not-before="0s" \
-  --not-after="44520h"
+# Update helm repos to ensure you have the latest version
+helm repo update
 
-TLS_ROOT_CRT=`cat root-tls.crt | sed 's/^/        /'`
-TLS_ROOT_KEY=`cat root-tls.key | sed 's/^/        /'`
+# Install the step-certificates helm chart.
+helm install mysteprelease -f ./values.yml smallstep/step-certificate
 
-# Generate Intermediate CA Certificate Pair
-step certificate create \
-  "${INTERMEDIATE_CA_NAME}" \
-  "intermediate-tls.crt" \
-  "intermediate-tls.key" \
-  --template="intermediate-tls.json" \
-  --kty="EC" \
-  --curve="P-256" \
-  --password-file="intermediate-tls.password" \
-  --not-before="0s" \
-  --not-after="17760h" \
-  --ca="root-tls.crt" \
-  --ca-key="root-tls.key" \
-  --ca-password-file="root-tls.password"
-
-TLS_INTERMEDIATE_CRT=`cat intermediate-tls.crt | sed 's/^/        /'`
-TLS_INTERMEDIATE_KEY=`cat intermediate-tls.key | sed 's/^/        /'`
-
-# Generate SSH Host CA Password
-SSH_HOST_PASSWORD=`tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_\`{|}~' </dev/urandom | head -c 64 | tee host-ssh.password`
-SSH_HOST_PASSWORD_B64=`echo ${SSH_HOST_PASSWORD} | base64 --wrap=0`
-
-# Generate SSH Host CA Keypair
-ssh-keygen -q -t ecdsa -b 256 -f host-ssh.key -C "SSH Host Key" -N ${SSH_HOST_PASSWORD}
-
-SSH_HOST_CRT=`cat host-ssh.key.pub`
-SSH_HOST_KEY=`cat host-ssh.key | sed 's/^/        /'`
-
-# Generate SSH User CA Password
-SSH_USER_PASSWORD=`tr -dc 'A-Za-z0-9!"#$%&'\''()*+,-./:;<=>?@[\]^_\`{|}~' </dev/urandom | head -c 64 | tee user-ssh.password`
-SSH_USER_PASSWORD_B64=`echo ${SSH_USER_PASSWORD} | base64 --wrap=0`
-
-# Generate SSH User CA Keypair
-ssh-keygen -q -t ecdsa -b 256 -f user-ssh.key -C "SSH User Key" -N ${SSH_USER_PASSWORD}
-
-SSH_USER_CRT=`cat user-ssh.key.pub`
-SSH_USER_KEY=`cat user-ssh.key | sed 's/^/        /'`
-
-export ROOT_TLS_PASSWORD_B64 INTERMEDIATE_TLS_PASSWORD_B64 TLS_ROOT_CRT TLS_ROOT_KEY TLS_INTERMEDIATE_CRT TLS_INTERMEDIATE_KEY SSH_HOST_PASSWORD_B64 SSH_HOST_CRT SSH_HOST_KEY SSH_USER_PASSWORD_B64 SSH_USER_CRT SSH_USER_KEY
-
-cat values.yml.tpl | envsubst | tee values.yml
+# Save generated files somewhere safe then remove from your local machine
+rm -f ./*.yml ./*.json ./*.crt ./*.key ./*.pub ./*.password
 ```
 
 ## Registration Authority Connected to Smallstep Certificate Manager Hosted Certificate Authority.
@@ -108,7 +73,7 @@ sed -e "s/your-base-64-encoded-key-password/${JWK_ISSUER_PASSWORD}/g" -i step_va
 helm repo add smallstep https://smallstep.github.io/helm-charts/
 
 # Update helm repos to ensure you have the latest version
-helm repo update smallstep
+helm repo update
 
 # Install the step-certificates helm chart.
 helm install -f step_values.yml smallstep/step-certificates

--- a/step-certificates/examples/certificate_authority_single_instance/.gitignore
+++ b/step-certificates/examples/certificate_authority_single_instance/.gitignore
@@ -1,0 +1,6 @@
+*.json
+*.crt
+*.key
+*.key.pub
+*.password
+*.yml

--- a/step-certificates/examples/certificate_authority_single_instance/.gitignore
+++ b/step-certificates/examples/certificate_authority_single_instance/.gitignore
@@ -1,6 +1,6 @@
 *.json
 *.crt
 *.key
-*.key.pub
+*.pub
 *.password
 *.yml

--- a/step-certificates/examples/certificate_authority_single_instance/ca.config
+++ b/step-certificates/examples/certificate_authority_single_instance/ca.config
@@ -1,0 +1,12 @@
+{
+  "root_ca_name": "example-root-ca",
+  "intermediate_ca_name": "example-intermediate-ca",
+  "ca_org_name": "Example CA Org",
+  "ca_country_name": "US",
+  "ca_locality_name": "Minnesota",
+  "ca_dns_names": [
+    "ca.example.com",
+    "mysteprelease-step-certificates.default.svc.cluster.local",
+    "127.0.0.1"
+  ]
+}

--- a/step-certificates/examples/certificate_authority_single_instance/ca.config
+++ b/step-certificates/examples/certificate_authority_single_instance/ca.config
@@ -8,5 +8,7 @@
     "ca.example.com",
     "mysteprelease-step-certificates.default.svc.cluster.local",
     "127.0.0.1"
-  ]
+  ],
+  "jwk_provisioner_name": "admin",
+  "ca_url": "mysteprelease-step-certificates.default.svc.cluster.local"
 }

--- a/step-certificates/examples/certificate_authority_single_instance/generate-values.sh
+++ b/step-certificates/examples/certificate_authority_single_instance/generate-values.sh
@@ -1,8 +1,3 @@
-# Helm Configuration Examples
-
-## Self Hosted Single Instance Certificate Authority
-
-```bash
 ROOT_CA_NAME='example-root-ca'
 INTERMEDIATE_CA_NAME='example-intermediate-ca'
 CA_ORG_NAME='Example CA Org'
@@ -74,42 +69,3 @@ SSH_USER_KEY=`cat user-ssh.key | sed 's/^/        /'`
 export ROOT_TLS_PASSWORD_B64 INTERMEDIATE_TLS_PASSWORD_B64 TLS_ROOT_CRT TLS_ROOT_KEY TLS_INTERMEDIATE_CRT TLS_INTERMEDIATE_KEY SSH_HOST_PASSWORD_B64 SSH_HOST_CRT SSH_HOST_KEY SSH_USER_PASSWORD_B64 SSH_USER_CRT SSH_USER_KEY
 
 cat values.yml.tpl | envsubst | tee values.yml
-```
-
-## Registration Authority Connected to Smallstep Certificate Manager Hosted Certificate Authority.
-
-```bash
-CA_NAME='example-ca'
-CA_FINGERPRINT='ca-fingerprint'
-ORG_NAME='example-org'
-
-# Install Step If Not already installed.
-brew install step
-
-# Bootstrap Step against the CA if not already bootstrapped.
-step ca bootstrap --ca-url https://${CA_NAME}.${ORG_NAME}.ca.smallstep.com --fingerprint ${CA_FINGERPRINT}
-
-# Create a registration-authority JWK Provisioner
-step beta ca provisioner add registration-authority --create
-
-# Encode the JWK Provisioner password in base64
-JWK_ISSUER_PASSWORD=`echo 'your-password-here' | base64`
-
-# Download the example values.yml
-curl -o step_values.yml https://raw.githubusercontent.com/smallstep/helm-charts/master/step-certificates/examples/registration_authority/values.yml
-
-# Replace dummy values with your own values
-sed -e "s/your-ca-name/${CA_NAME}/g" -i step_values.yml
-sed -e "s/your-org/${ORG_NAME}/g" -i step_values.yml
-sed -e "s/your-ca-fingerprint-here/${CA_FINGERPRINT}/g" -i step_values.yml
-sed -e "s/your-base-64-encoded-key-password/${JWK_ISSUER_PASSWORD}/g" -i step_values.yml
-
-# Add the smallstep helm repo, if not already added
-helm repo add smallstep https://smallstep.github.io/helm-charts/
-
-# Update helm repos to ensure you have the latest version
-helm repo update smallstep
-
-# Install the step-certificates helm chart.
-helm install -f step_values.yml smallstep/step-certificates
-```

--- a/step-certificates/examples/certificate_authority_single_instance/generate-values.sh
+++ b/step-certificates/examples/certificate_authority_single_instance/generate-values.sh
@@ -4,8 +4,10 @@ CA_ORG_NAME=`jq -r '.ca_org_name' ca.config`
 CA_COUNTRY_NAME=`jq -r '.ca_country_name' ca.config`
 CA_LOCALITY_NAME=`jq -r '.ca_locality_name' ca.config`
 CA_DNS_NAMES=`jq -c .ca_dns_names ca.config`
+CA_URL=`jq -r .ca_url ca.config`
+JWK_PROVISIONER_NAME=`jq -r .jwk_provisioner_name ca.config`
 
-export ROOT_CA_NAME INTERMEDIATE_CA_NAME CA_ORG_NAME CA_COUNTRY_NAME CA_LOCALITY_NAME CA_DNS_NAMES
+export ROOT_CA_NAME INTERMEDIATE_CA_NAME CA_ORG_NAME CA_COUNTRY_NAME CA_LOCALITY_NAME CA_DNS_NAMES CA_URL JWK_PROVISIONER_NAME
 
 # Write Out Root and Intermediate Certificate Templates
 cat root-tls.json.tpl | envsubst | tee root-tls.json
@@ -30,6 +32,7 @@ step certificate create \
 
 TLS_ROOT_CRT=`cat root-tls.crt | sed 's/^/        /'`
 TLS_ROOT_KEY=`cat root-tls.key | sed 's/^/        /'`
+TLS_ROOT_FINGERPRINT=`step certificate fingerprint root-tls.crt`
 
 # Generate Intermediate CA Certificate Pair
 step certificate create \
@@ -91,7 +94,7 @@ JWK_PROVISIONER_CRT_X=`jq '.x' -r jwk_provisioner.pub`
 JWK_PROVISIONER_CRT_Y=`jq '.y' -r jwk_provisioner.pub`
 
 export \
-  ROOT_TLS_PASSWORD_B64 TLS_ROOT_CRT TLS_ROOT_KEY\
+  ROOT_TLS_PASSWORD_B64 TLS_ROOT_CRT TLS_ROOT_KEY TLS_ROOT_FINGERPRINT \
   INTERMEDIATE_TLS_PASSWORD_B64 TLS_INTERMEDIATE_CRT TLS_INTERMEDIATE_KEY \
   SSH_HOST_PASSWORD_B64 SSH_HOST_CRT SSH_HOST_KEY \
   SSH_USER_PASSWORD_B64 SSH_USER_CRT SSH_USER_KEY \

--- a/step-certificates/examples/certificate_authority_single_instance/intermediate-tls.json.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/intermediate-tls.json.tpl
@@ -1,0 +1,19 @@
+{
+  "subject": {
+    "commonName": "${INTERMEDIATE_CA_NAME}",
+    "organizationName": "${CA_ORG_NAME}",
+    "countryName": "${CA_COUNTRY_NAME}",
+    "localityName": "${CA_LOCALITY_NAME}"
+  },
+  "issuer": {
+    "commonName": "${ROOT_CA_NAME}",
+    "organizationName": "${CA_ORG_NAME}",
+    "countryName": "${CA_COUNTRY_NAME}",
+    "localityName": "${CA_LOCALITY_NAME}"
+  },
+  "keyUsage": [ "certSign", "crlSign" ],
+  "basicConstraints": {
+    "isCA": true,
+    "maxPathLen": 1
+  }
+}

--- a/step-certificates/examples/certificate_authority_single_instance/intermediate-tls.json.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/intermediate-tls.json.tpl
@@ -5,12 +5,6 @@
     "countryName": "${CA_COUNTRY_NAME}",
     "localityName": "${CA_LOCALITY_NAME}"
   },
-  "issuer": {
-    "commonName": "${ROOT_CA_NAME}",
-    "organizationName": "${CA_ORG_NAME}",
-    "countryName": "${CA_COUNTRY_NAME}",
-    "localityName": "${CA_LOCALITY_NAME}"
-  },
   "keyUsage": [ "certSign", "crlSign" ],
   "basicConstraints": {
     "isCA": true,

--- a/step-certificates/examples/certificate_authority_single_instance/root-tls.json.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/root-tls.json.tpl
@@ -5,12 +5,6 @@
     "countryName": "${CA_COUNTRY_NAME}",
     "localityName": "${CA_LOCALITY_NAME}"
   },
-  "issuer": {
-    "commonName": "${ROOT_CA_NAME}",
-    "organizationName": "${CA_ORG_NAME}",
-    "countryName": "${CA_COUNTRY_NAME}",
-    "localityName": "${CA_LOCALITY_NAME}"
-  },
   "keyUsage": [ "certSign", "crlSign" ],
   "basicConstraints": {
     "isCA": true,

--- a/step-certificates/examples/certificate_authority_single_instance/root-tls.json.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/root-tls.json.tpl
@@ -1,0 +1,19 @@
+{
+  "subject": {
+    "commonName": "${ROOT_CA_NAME}",
+    "organizationName": "${CA_ORG_NAME}",
+    "countryName": "${CA_COUNTRY_NAME}",
+    "localityName": "${CA_LOCALITY_NAME}"
+  },
+  "issuer": {
+    "commonName": "${ROOT_CA_NAME}",
+    "organizationName": "${CA_ORG_NAME}",
+    "countryName": "${CA_COUNTRY_NAME}",
+    "localityName": "${CA_LOCALITY_NAME}"
+  },
+  "keyUsage": [ "certSign", "crlSign" ],
+  "basicConstraints": {
+    "isCA": true,
+    "maxPathLen": 1
+  }
+}

--- a/step-certificates/examples/certificate_authority_single_instance/values.yml.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/values.yml.tpl
@@ -1,0 +1,116 @@
+kind: StatefulSet
+replicaCount: 1
+autocert:
+  enabled: false
+bootstrap:
+  enabled: false
+ca:
+  db:
+      enabled: true
+      persistent: false
+inject:
+  enabled: true
+  config:
+    files:
+      ca.json:
+        root: /home/step/certs/root_ca.crt
+        federateRoots: []
+        crt: /home/step/certs/intermediate_ca.crt
+        key: /home/step/secrets/intermediate_ca_key
+        address: 0.0.0.0:9000
+        dnsNames:
+          - ca.example.com
+          - mysteprelease-step-certificates.default.svc.cluster.local
+          - 127.0.0.1
+        logger:
+          format: json
+        db:
+          type: badger
+          dataSource: /home/step/db
+        authority:
+          claims:
+            minTLSCertDuration: 5m
+            maxTLSCertDuration: 24h
+            defaultTLSCertDuration: 24h
+            disableRenewal: false
+            minHostSSHCertDuration: 5m
+            maxHostSSHCertDuration: 1680h
+            defaultHostSSHCertDuration: 720h
+            minUserSSHCertDuration: 5m
+            maxUserSSHCertDuration: 24h
+            defaultUserSSHCertDuration: 24h
+          provisioners:
+            - type: ACME
+              name: acme
+              forceCN: true
+              claims: {}
+        tls:
+          cipherSuites:
+            - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+            - TLS_AES_128_GCM_SHA256
+          minVersion: 1.2
+          maxVersion: 1.3
+          renegotiation: false
+      defaults.json:
+        ca-url: https://mysteprelease-step-certificates.default.svc.cluster.local
+        ca-config: /home/step/config/ca.json
+        fingerprint: fingerprint
+        root: /home/step/certs/root_ca.crt
+    templates:
+      x509_leaf.tpl: |
+        {
+          "subject": {{ toJson .Subject }},
+          "sans": {{ toJson .SANs }},
+        {{- if typeIs "*rsa.PublicKey" .Insecure.CR.PublicKey }}
+          "keyUsage": ["keyEncipherment", "digitalSignature"],
+        {{- else }}
+          "keyUsage": ["digitalSignature"],
+        {{- end }}
+          "extKeyUsage": ["serverAuth", "clientAuth"]
+        }
+      ssh.tpl: |
+        {
+          "type": {{ toJson .Type }},
+          "keyId": {{ toJson .KeyID }},
+          "principals": {{ toJson .Principals }},
+          "extensions": {{ toJson .Extensions }},
+          "criticalOptions": {{ toJson .CriticalOptions }}
+        }
+  certificates:
+    intermediate_ca: |
+${TLS_INTERMEDIATE_CRT}
+    root_ca: |
+${TLS_ROOT_CRT}
+    ssh_host_ca: "${SSH_HOST_CRT}"
+    ssh_user_ca: "${SSH_USER_CRT}"
+  secrets:
+    ca_password: "${INTERMEDIATE_TLS_PASSWORD_B64}"
+    provisioner_password: ""
+    certificate_issuer:
+      enabled: false
+    x509:
+      enabled: true
+      intermediate_ca_key: |
+${TLS_INTERMEDIATE_KEY}
+      root_ca_key: |
+${TLS_ROOT_KEY}
+    ssh:
+      enabled: true
+      host_ca_key: |
+${SSH_HOST_KEY}
+      host_ca_password: "${SSH_HOST_PASSWORD_B64}"
+      user_ca_key: |
+${SSH_USER_KEY}
+      user_ca_password: "${SSH_USER_PASSWORD_B64}"
+service:
+  type: ClusterIP
+  port: 443
+  targetPort: 9000
+  nodePort: 32400
+ingress:
+  enabled: false
+  annotations: {}
+  hosts: []
+  tls: []
+

--- a/step-certificates/examples/certificate_authority_single_instance/values.yml.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/values.yml.tpl
@@ -18,10 +18,7 @@ inject:
         crt: /home/step/certs/intermediate_ca.crt
         key: /home/step/secrets/intermediate_ca_key
         address: 0.0.0.0:9000
-        dnsNames:
-          - ca.example.com
-          - mysteprelease-step-certificates.default.svc.cluster.local
-          - 127.0.0.1
+        dnsNames: ${CA_DNS_NAMES}
         logger:
           format: json
         db:
@@ -44,6 +41,23 @@ inject:
               name: acme
               forceCN: true
               claims: {}
+            - type: SSHPOP
+              name: sshpop
+              claims:
+                enableSSHCA: true
+            - type: JWK
+              name: ansible_automation_token
+              key: 
+                alg: "${JWK_PROVISIONER_CRT_ALG}"
+                crv: "${JWK_PROVISIONER_CRT_CRV}"
+                kid: "${JWK_PROVISIONER_CRT_KID}"
+                kty: "${JWK_PROVISIONER_CRT_KTY}"
+                use: "${JWK_PROVISIONER_CRT_USE}"
+                x: "${JWK_PROVISIONER_CRT_X}"
+                'y': "${JWK_PROVISIONER_CRT_Y}"
+              encryptedKey: "${JWK_PROVISIONER_KEY}"
+              claims:
+                enableSSHCA: true
         tls:
           cipherSuites:
             - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
@@ -86,7 +100,7 @@ ${TLS_ROOT_CRT}
     ssh_user_ca: "${SSH_USER_CRT}"
   secrets:
     ca_password: "${INTERMEDIATE_TLS_PASSWORD_B64}"
-    provisioner_password: ""
+    provisioner_password: "${JWK_PROVISIONER_PASSWORD_B64}"
     certificate_issuer:
       enabled: false
     x509:

--- a/step-certificates/examples/certificate_authority_single_instance/values.yml.tpl
+++ b/step-certificates/examples/certificate_authority_single_instance/values.yml.tpl
@@ -46,7 +46,7 @@ inject:
               claims:
                 enableSSHCA: true
             - type: JWK
-              name: ansible_automation_token
+              name: ${JWK_PROVISIONER_NAME}
               key: 
                 alg: "${JWK_PROVISIONER_CRT_ALG}"
                 crv: "${JWK_PROVISIONER_CRT_CRV}"
@@ -67,9 +67,9 @@ inject:
           maxVersion: 1.3
           renegotiation: false
       defaults.json:
-        ca-url: https://mysteprelease-step-certificates.default.svc.cluster.local
+        ca-url: ${CA_URL}
         ca-config: /home/step/config/ca.json
-        fingerprint: fingerprint
+        fingerprint: ${TLS_ROOT_FINGERPRINT}
         root: /home/step/certs/root_ca.crt
     templates:
       x509_leaf.tpl: |

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -149,12 +149,12 @@ spec:
           secretName: {{ include "step-certificates.fullname" . }}-certificate-issuer-password
       {{- end }}
       {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.host_ca_password ""))) }}
-      - name: certificate-issuer
+      - name: ssh-host-ca-password
         secret:
           secretName: {{ include "step-certificates.fullname" . }}-ssh-host-ca-password
       {{- end }}
       {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.user_ca_password ""))) }}
-      - name: certificate-issuer
+      - name: ssh-user-ca-password
         secret:
           secretName: {{ include "step-certificates.fullname" . }}-ssh-user-ca-password
       {{- end }}

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -48,6 +48,12 @@ spec:
             {{- if or (and .Values.bootstrap.enabled .Values.bootstrap.secrets) (and .Values.inject.enabled (not (eq .Values.inject.secrets.ca_password ""))) }}
             "--password-file", "/home/step/secrets/passwords/password",
             {{- end }}
+            {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.host_ca_password ""))) }}
+            "--ssh-host-ca-key-password", "/home/step/secrets/ssh-host-ca/password",
+            {{- end }}
+            {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.user_ca_password ""))) }}
+            "--ssh-client-ca-key-password", "/home/step/secrets/ssh-user-ca/password",
+            {{- end }}
             "/home/step/config/ca.json"
           ]
           env:
@@ -107,6 +113,16 @@ spec:
             mountPath: /home/step/secrets/certificate-issuer
             readOnly: true
           {{- end }}
+          {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.host_ca_password ""))) }}
+          - name: ssh-host-ca-password
+            mountPath: /home/step/secrets/ssh-host-ca
+            readOnly: true
+          {{- end }}
+          {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.user_ca_password ""))) }}
+          - name: ssh-user-ca-password
+            mountPath: /home/step/secrets/ssh-user-ca
+            readOnly: true
+          {{- end }}
       volumes:
       - name: certs
         configMap:
@@ -131,6 +147,16 @@ spec:
       - name: certificate-issuer
         secret:
           secretName: {{ include "step-certificates.fullname" . }}-certificate-issuer-password
+      {{- end }}
+      {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.host_ca_password ""))) }}
+      - name: certificate-issuer
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-ssh-host-ca-password
+      {{- end }}
+      {{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.user_ca_password ""))) }}
+      - name: certificate-issuer
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-ssh-user-ca-password
       {{- end }}
       {{- if and .Values.ca.db.enabled (not .Values.ca.db.persistent) }}
       - name: database

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -43,6 +43,28 @@ data:
   password: {{ .Values.inject.secrets.certificate_issuer.password }}
 {{- end }}
 ---
+{{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.host_ca_password ""))) }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/ssh-host-ca-password
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-ssh-host-ca-password
+  namespace: {{ .Release.Namespace }}
+data:
+  password: {{ .Values.inject.secrets.ssh.host_ca_password }}
+{{- end }}
+---
+{{- if and .Values.inject.enabled (and .Values.inject.secrets.ssh.enabled (not (eq .Values.inject.secrets.ssh.user_ca_password ""))) }}
+apiVersion: v1
+kind: Secret
+type: smallstep.com/ssh-user-ca-password
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-ssh-user-ca-password
+  namespace: {{ .Release.Namespace }}
+data:
+  password: {{ .Values.inject.secrets.ssh.user_ca_password }}
+{{- end }}
+---
 {{- if .Values.inject.enabled }}
 apiVersion: v1
 kind: Secret

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -185,6 +185,7 @@ inject:
       #   -----BEGIN OPENSSH PRIVATE KEY-----
       #   ...
       #   -----END OPENSSH PRIVATE KEY-----
+      host_ca_password: ""
 
       # ssh_user_ca_key contains the contents of your encrypted SSH User CA key
       user_ca_key: ""
@@ -192,6 +193,8 @@ inject:
       #   -----BEGIN OPENSSH PRIVATE KEY-----
       #   ...
       #   -----END OPENSSH PRIVATE KEY-----
+      user_ca_password: ""
+
 
 # service contains configuration for the kubernetes service.
 service:


### PR DESCRIPTION
Adds capability to inject SSH Host and Client CA passwords as part of

https://github.com/smallstep/certificates/issues/693

Cannot be merged until the functionality in the following pull request is released.

https://github.com/smallstep/certificates/pull/707

Adds example code for generating key material for a non-persistent smallstep instance that serves both TLS and SSH certificates.