### PR TITLE
Use correct syntax for Ingress backend.

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.17.4
+version: 1.17.5
 appVersion: 0.17.4
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/templates/ingress.yaml
+++ b/step-certificates/templates/ingress.yaml
@@ -36,8 +36,10 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/step-certificates/templates/ingress.yaml
+++ b/step-certificates/templates/ingress.yaml
@@ -36,10 +36,15 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+{{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+{{- end }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR fixes an issue where the Ingress template creates Ingress objects with malformed syntax. #69