### PR TITLE
Inject values but not secrets

### DIFF
--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -43,7 +43,7 @@ data:
   password: {{ .Values.inject.secrets.certificate_issuer.password }}
 {{- end }}
 ---
-{{- if .Values.inject.enabled }}
+{{- if and .Values.inject.enabled .Values.bootstrap.secrets}}
 apiVersion: v1
 kind: Secret
 type: smallstep.com/private-keys


### PR DESCRIPTION
Helm won't try to create secrets if .Values.bootstrap.secrets is false.
Allows for secrets to be already deployed in some other manner.