### PR TITLE
Inject values but not secrets

### DIFF
--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -65,7 +65,7 @@ data:
   password: {{ .Values.inject.secrets.ssh.user_ca_password }}
 {{- end }}
 ---
-{{- if .Values.inject.enabled }}
+{{- if and .Values.inject.enabled .Values.bootstrap.secrets}}
 apiVersion: v1
 kind: Secret
 type: smallstep.com/private-keys


### PR DESCRIPTION
Now Helm won't try to create secrets if .Values.bootstrap.secrets is false.
Allows for secrets to be already deployed in some other manner.