### PR TITLE
Add missing namespace for step-certificates

### DIFF
--- a/step-certificates/templates/bootstrap.yaml
+++ b/step-certificates/templates/bootstrap.yaml
@@ -12,6 +12,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ .Release.Name }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 spec:

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: {{ .Values.kind }}
 metadata:
   name: {{ include "step-certificates.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 spec:

--- a/step-certificates/templates/ingress.yaml
+++ b/step-certificates/templates/ingress.yaml
@@ -12,6 +12,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "step-certificates.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
 spec:

--- a/step-certificates/templates/tests/test-connection.yaml
+++ b/step-certificates/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "step-certificates.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Hi - I found that `namespace` wasn't being applied to resources consistently in the `step-certificates` chart. Originally I had some failures after templating+applying since resources were created across `--namespace=` and my default namespace.