### PR TITLE
Support annotations in service

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -126,6 +126,7 @@ chart and their default values.
 | `service.port`                | Incoming port to access Step CA                                                                             | `443`                                    |
 | `service.nodePort`            | Incoming port to access Step CA                                                                             | `""`                                     |
 | `service.targetPort`          | Internal port where Step CA runs                                                                            | `9000`                                   |
+| `service.annotations`         | Service annotations (YAML)                                                                                  | `{}`                                     |
 | `replicaCount`                | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
 | `image.repository`            | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
 | `image.initContainerRepository` | Repository of the Step CA Init Container image.                                                           | `busybox:latest`                         |

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -202,6 +202,7 @@ service:
   port: 443
   targetPort: 9000
   nodePort: ""
+  annotations: {}
 
 # linkedca contains the token to configure step-ca using the linkedca mode.
 #


### PR DESCRIPTION
In some cases, we need to put some annotations for the service section.

```
service:
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
```