### PR TITLE
add full airgapped

### DIFF
--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ include "step-issuer.serviceAccountName" . }}
       {{- end }}
       containers:
-      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+      - image: "{{ .Values.kubeRBACproxy.image.repository }}:{{ .Values.kubeRBACproxy.image.tag }}"
         name: kube-rbac-proxy
         args: ["--secure-listen-address=0.0.0.0:8443", "--upstream=http://127.0.0.1:8080/", "--logtostderr=true", "--v=10"]
         ports:

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -10,6 +10,11 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+kubeRBACproxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    tag: v0.8.0
+
 # List of secret keys used to pull images from private registries.
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
I've added a variable for kube-rbac-proxy image and tag. With a default value of the already present Value. 
This will enable step-issuer for full airgapped clusters without changing the template files.

Fixes #87