### PR TITLE
Feature/#91 azurekms support

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -134,6 +134,10 @@ chart and their default values.
 | `ca.db.accessModes`           | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
 | `ca.db.size`                  | Persistent volume size                                                                                      | `10Gi`                                   |
 | `ca.db.existingClaim`         | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
+| `ca.kms.type`                 | Key management system to use.                                                                               | `""`                                     |
+| `ca.kms.id`                   | Identifier for KMS authentication (e.g. Azure KeyVault ClientID)                                            | `""`                                     |
+| `ca.kms.secret`               | Secret/password for KMS authentication (e.g. Azure KeyVault ClientSecret)                                   | `""`                                     |
+| `ca.kms.tenant`               | Tenant for KMS authentication (e.g. Azure KeyVault TenantID)                                                | `""`                                     |
 | `ca.runAsRoot`                | Run the CA as root.                                                                                         | `false`                                  |
 | `ca.bootstrap.postInitHook`   | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
 | `linkedca.token`              | The token used to configure step-ca using the linkedca mode.                                                | `""`                                     |

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -134,10 +134,8 @@ chart and their default values.
 | `ca.db.accessModes`           | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
 | `ca.db.size`                  | Persistent volume size                                                                                      | `10Gi`                                   |
 | `ca.db.existingClaim`         | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
-| `ca.kms.type`                 | Key management system to use.                                                                               | `""`                                     |
-| `ca.kms.id`                   | Identifier for KMS authentication (e.g. Azure KeyVault ClientID)                                            | `""`                                     |
-| `ca.kms.secret`               | Secret/password for KMS authentication (e.g. Azure KeyVault ClientSecret)                                   | `""`                                     |
-| `ca.kms.tenant`               | Tenant for KMS authentication (e.g. Azure KeyVault TenantID)                                                | `""`                                     |
+| `ca.kms`                      | Key management system to use.                                                                               | `""`                                     |
+| `ca.env`                      | Environment variables to set in `step-certificates` container.                                              | `[]`                                     |
 | `ca.runAsRoot`                | Run the CA as root.                                                                                         | `false`                                  |
 | `ca.bootstrap.postInitHook`   | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
 | `linkedca.token`              | The token used to configure step-ca using the linkedca mode.                                                | `""`                                     |

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -65,11 +65,13 @@ spec:
           env:
           - name: NAMESPACE
             value: "{{ .Release.Namespace }}"
-          {{- if eq .Values.ca.kms.type "azurekms"}}
+          {{- if .Values.ca.kms.type }}
           - name: AZURE_CLIENT_ID
-            value: {{ .Values.ca.kms.id | quote }}
+            value: "{{ .Values.ca.kms.id }}"
           - name: AZURE_CLIENT_SECRET
-            value: {{ .Values.ca.kms.secret | quote }}
+            value: "{{ .Values.ca.kms.secret }}"
+          - name: AZURE_TENANT_ID
+            value: "{{ .Values.ca.kms.tenant }}"
           {{- end }}
           {{- if or .Values.linkedca.token (and .Values.linkedca.secretKeyRef.name .Values.linkedca.secretKeyRef.key) }}
           - name: STEP_CA_TOKEN

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -65,13 +65,8 @@ spec:
           env:
           - name: NAMESPACE
             value: "{{ .Release.Namespace }}"
-          {{- if .Values.ca.kms.type }}
-          - name: AZURE_CLIENT_ID
-            value: "{{ .Values.ca.kms.id }}"
-          - name: AZURE_CLIENT_SECRET
-            value: "{{ .Values.ca.kms.secret }}"
-          - name: AZURE_TENANT_ID
-            value: "{{ .Values.ca.kms.tenant }}"
+          {{- if .Values.ca.env }}
+            {{- toYaml .Values.ca.env | nindent 10 }}
           {{- end }}
           {{- if or .Values.linkedca.token (and .Values.linkedca.secretKeyRef.name .Values.linkedca.secretKeyRef.key) }}
           - name: STEP_CA_TOKEN

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -65,6 +65,12 @@ spec:
           env:
           - name: NAMESPACE
             value: "{{ .Release.Namespace }}"
+          {{- if eq .Values.ca.kms.type "azurekms"}}
+          - name: AZURE_CLIENT_ID
+            value: {{ .Values.ca.kms.id | quote }}
+          - name: AZURE_CLIENT_SECRET
+            value: {{ .Values.ca.kms.secret | quote }}
+          {{- end }}
           {{- if or .Values.linkedca.token (and .Values.linkedca.secretKeyRef.name .Values.linkedca.secretKeyRef.key) }}
           - name: STEP_CA_TOKEN
             valueFrom:

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -148,6 +148,7 @@ data:
       --provisioner "{{.Values.ca.provisioner.name}}" \
       --with-ca-url "{{include "step-certificates.url" .}}" \
       --password-file "$TMP_CA_PASSWORD" \
+      {{ if not (eq .Values.ca.kms.type "") }}--kms="{{.Values.ca.kms.type}}" \{{ end }}
       --provisioner-password-file "$TMP_CA_PROVISIONER_PASSWORD" {{ if not .Values.ca.db.enabled }}--no-db{{ end }}
 
     rm -f $TMP_CA_PASSWORD $TMP_CA_PROVISIONER_PASSWORD

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -236,7 +236,7 @@ ca:
     name: admin
     # password is the password used to encrypt the provisioner private key.
     password:
-  # db contains the step-certificate dataabase configuration.
+  # db contains the step-certificate database configuration.
   db:
     # enabled defines if the database is enabled.
     enabled: true
@@ -257,6 +257,16 @@ ca:
     - ReadWriteOnce
     # size is the Persistent Volume size.
     size: 10Gi
+  # kms contains the step-certificates key management system configuration
+  kms:
+    # type of KMS to use (e.g. azurekms for Azure KeyVault)
+    type: ""
+    # identifier for KMS credentials (e.g. service principal ClientID for Azure)
+    id: ""
+    # secret for KMS credentials (e.g. service principal ClientSecret for Azure)
+    secret: ""
+    # secret for KMS credentials (e.g. service principal ClientSecret for Azure)
+    tenant: ""
   # runAsRoot runs the ca as root instead of the step user. This is required in
   # some storage provisioners.
   runAsRoot: false

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -257,16 +257,10 @@ ca:
     - ReadWriteOnce
     # size is the Persistent Volume size.
     size: 10Gi
-  # kms contains the step-certificates key management system configuration
-  kms:
-    # type of KMS to use (e.g. azurekms for Azure KeyVault)
-    type: ""
-    # identifier for KMS credentials (e.g. service principal ClientID for Azure)
-    id: ""
-    # secret for KMS credentials (e.g. service principal ClientSecret for Azure)
-    secret: ""
-    # secret for KMS credentials (e.g. service principal ClientSecret for Azure)
-    tenant: ""
+  # kms type to utilize 
+  kms: ""
+  # additional environment variables to set in the step-certificates container
+  env: []
   # runAsRoot runs the ca as root instead of the step user. This is required in
   # some storage provisioners.
   runAsRoot: false


### PR DESCRIPTION
Wanted to open this and get eyes on it.  Certainly open to potential implementation changes, but tried to generalize the settings enough that it could be extended for use with other KMS platforms.

In short, this allows optionally specifying a KMS along with credentials.  This was primarily focused around my use case (Azure KeyVault) and based on the docs [here](https://smallstep.com/docs/step-ca/configuration/#azure-key-vault)

Let me know what you think / any updates that could or should be made.  Appears to be functional on my end, though I had to manually add the `kms` to ca.json in the values file generated by `step ca --init` locally and used to stand this up.  I'll be opening a separate PR for that in the respective step-certificates repository.

Fixes/implements #91.