### PR TITLE
Fixes typo

### DIFF
--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           "--enable-leader-election",
           {{- end }}
           {{- if .Values.deployment.args.disableApprovalCheck }}
-          ---disable-approval-check,
+          "--disable-approval-check",
           {{- end }}
         ]
         command: ["/manager"]


### PR DESCRIPTION
Removes the extra "-" to the parameter and quotes it like the rest of args provided.

