### PR TITLE
Add support for ingressClassName in step-certificates ingress

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: step-certificates
-version: 1.18.1
-appVersion: 0.18.1
+version: 1.18.2
+appVersion: 0.18.2
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:
  - acme

--- a/step-certificates/templates/ingress.yaml
+++ b/step-certificates/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -258,7 +258,8 @@ ca:
     # size is the Persistent Volume size.
     size: 10Gi
   # kms type to utilize 
-  kms: ""
+  kms:
+    type: ""
   # additional environment variables to set in the step-certificates container
   env: []
   # runAsRoot runs the ca as root instead of the step user. This is required in
@@ -276,6 +277,7 @@ autocert:
 ingress:
   enabled: false
   annotations: {}
+  ingressClassName: ""
   hosts: []
   tls: []
 


### PR DESCRIPTION
### Description

This PR adds support for setting the `spec.ingressClassName` property in the step-certificates ingress.

Fixes #94 