### PR TITLE
add stepClusterIssuer template

### DIFF
--- a/step-issuer/templates/stepclusterissuer.yaml
+++ b/step-issuer/templates/stepclusterissuer.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.stepClusterIssuer.create }}
+apiVersion: certmanager.step.sm/v1beta1
+kind: StepClusterIssuer
+metadata:
+  name: "{{ template "step-issuer.fullname" . }}"
+spec:
+  # The CA URL.
+  url: https://step-certificates.{{ .Release.Namespace }}.svc.cluster.local
+  # The base64 encoded version of the CA root certificate in PEM format.
+  caBundle: {{ .Values.stepClusterIssuer.caBundle }}
+  # The provisioner name, kid, and a reference to the provisioner password secret.
+  provisioner:
+    name: {{ .Values.stepClusterIssuer.provisioner.name }}
+    kid: {{ .Values.stepClusterIssuer.provisioner.kid }}
+    passwordRef:
+      name: {{ .Values.stepClusterIssuer.provisioner.passwordRef.name }}
+      namespace: {{ .Values.stepClusterIssuer.provisioner.passwordRef.namespace }}
+      key: {{ .Values.stepClusterIssuer.provisioner.passwordRef.key }}
+{{- end }}

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -63,6 +63,19 @@ stepIssuer:
       name: ""
       key: ""
 
+# mandatory values to generate stepClusterIssuer resource
+# please follow the https://github.com/smallstep/step-issuer#getting-started to setup step-ca and get step-issuer values
+stepClusterIssuer:
+  create: false
+  caBundle: ""
+  provisioner:
+    name: ""
+    kid: ""
+    passwordRef:
+      name: ""
+      namespace: ""
+      key: ""
+
 # For the cert-manager approver
 certManager:
   serviceAccount:


### PR DESCRIPTION
### Description
This PR adds a template for the StepClusterIssuer resource. Note that the resource itself is **not** namespaced but the `provisioner.passwordRef` is.
