### PR TITLE
feat: adds caUrl parameter for optional step-certificates service names

### DIFF
--- a/step-issuer/README.md
+++ b/step-issuer/README.md
@@ -42,17 +42,26 @@ deletes the release.
 The following table lists the configurable parameters of the Step Issuer chart
 and their default values.
 
-| Parameter                                 | Description                                                              | Default                             |
-| ----------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------- |
-| `replicaCount`                            | Number of Step Issuer replicas.                                          | `1`                                 |
-| `image.repository`                        | Repository of the Step Issuer image.                                     | `cr.step.sm/smallstep/step-issuer`  |
-| `image.tag`                               | Tag of the image. If empty it will use .Chart.appVersion.                | `""`                                |
-| `image.pullPolicy`                        | Step Issuer image pull policy                                            | `IfNotPresent`                      |
-| `deployment.args.enableLeaderElection`    | Enable k8s controller leader election.                                   | `true`                              |
-| `deployment.args.disableApprovalCheck`    | To disable cert-manager approvals on old version of cert-manager.        | `false`                             |
-| `stepIssuer.create`                       | If we should automatically create an step-issuer.                        | `false`                             |
-| `stepIssuer.caBundle`                     | Step Certificates root certificate in a single-line base64 string.       | `""`                                |
-| `stepIssuer.provisioner.name`             | Name of the provisioner used for authorizing the sign of certificates.   | `""`                                |
-| `stepIssuer.provisioner.kid`              | Key id of the provisioner used for authorizing the sign of certificates. | `""`                                |
-| `stepIssuer.provisioner.passwordRef.name` | Name of the secret with the provisioner password.                        | `""`                                |
-| `stepIssuer.provisioner.passwordRef.key`  | Key name in the the secret with the provisioner password.                | `""`                                |
+| Parameter                                              | Description                                                                                               | Default                             |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `replicaCount`                                         | Number of Step Issuer replicas.                                                                           | `1`                                 |
+| `image.repository`                                     | Repository of the Step Issuer image.                                                                      | `cr.step.sm/smallstep/step-issuer`  |
+| `image.tag`                                            | Tag of the image. If empty it will use .Chart.appVersion.                                                 | `""`                                |
+| `image.pullPolicy`                                     | Step Issuer image pull policy                                                                             | `IfNotPresent`                      |
+| `deployment.args.enableLeaderElection`                 | Enable k8s controller leader election.                                                                    | `true`                              |
+| `deployment.args.disableApprovalCheck`                 | To disable cert-manager approvals on old version of cert-manager.                                         | `false`                             |
+| `stepIssuer.create`                                    | If we should automatically create a StepIssuer                                                            | `false`                             |
+| `stepIssuer.caUrl`                                     | Step Certificates root certificate URL. This is normally the step-certificates service name.              | `"step-certificates"`               |
+| `stepIssuer.caBundle`                                  | Step Certificates root certificate in a single-line base64 string.                                        | `""`                                |
+| `stepIssuer.provisioner.name`                          | Name of the provisioner used for authorizing the sign of certificates.                                    | `""`                                |
+| `stepIssuer.provisioner.kid`                           | Key id of the provisioner used for authorizing the sign of certificates.                                  | `""`                                |
+| `stepIssuer.provisioner.passwordRef.name`              | Name of the secret with the provisioner password.                                                         | `""`                                |
+| `stepIssuer.provisioner.passwordRef.key`               | Key name in the the secret with the provisioner password.                                                 | `""`                                |
+| `stepClusterIssuer.create`                             | If we should automatically create a StepClusterIssuer                                                     | `false`                             |
+| `stepClusterIssuer.caUrl`                              | Step Certificates root certificate URL. This is normally the step-certificates service name.              | `"step-certificates"`               |
+| `stepClusterIssuer.caBundle`                           | Step Certificates root certificate in a single-line base64 string.                                        | `""`                                |
+| `stepClusterIssuer.provisioner.name`                   | Name of the provisioner used for authorizing the sign of certificates.                                    | `""`                                |
+| `stepClusterIssuer.provisioner.kid`                    | Key id of the provisioner used for authorizing the sign of certificates.                                  | `""`                                |
+| `stepClusterIssuer.provisioner.passwordRef.name`       | Name of the secret with the provisioner password.                                                         | `""`                                |
+| `stepClusterIssuer.provisioner.passwordRef.key`        | Key name in the the secret with the provisioner password.                                                 | `""`                                |
+| `stepClusterIssuer.provisioner.passwordRef.namespace`  | The namespace where the provisioner password secret resides.                                              | `""`                                |

--- a/step-issuer/templates/stepclusterissuer.yaml
+++ b/step-issuer/templates/stepclusterissuer.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ template "step-issuer.fullname" . }}"
 spec:
   # The CA URL.
-  url: https://step-certificates.{{ .Release.Namespace }}.svc.cluster.local
+  url: https://{{ .Values.stepClusterIssuer.caUrl }}.{{ .Release.Namespace }}.svc.cluster.local
   # The base64 encoded version of the CA root certificate in PEM format.
   caBundle: {{ .Values.stepClusterIssuer.caBundle }}
   # The provisioner name, kid, and a reference to the provisioner password secret.

--- a/step-issuer/templates/stepissuer.yml
+++ b/step-issuer/templates/stepissuer.yml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   # The CA URL.
-  url: https://step-certificates.{{ .Release.Namespace }}.svc.cluster.local
+  url: https://{{ .Values.stepIssuer.caUrl }}.{{ .Release.Namespace }}.svc.cluster.local
   # The base64 encoded version of the CA root certificate in PEM format.
   caBundle: {{ .Values.stepIssuer.caBundle }}
   # The provisioner name, kid, and a reference to the provisioner password secret.

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -55,6 +55,7 @@ serviceAccount:
 # please follow the https://github.com/smallstep/step-issuer#getting-started to setup step-ca and get step-issuer values
 stepIssuer:
   create: false
+  caUrl: "step-certificates"
   caBundle: ""
   provisioner:
     name: ""
@@ -67,6 +68,7 @@ stepIssuer:
 # please follow the https://github.com/smallstep/step-issuer#getting-started to setup step-ca and get step-issuer values
 stepClusterIssuer:
   create: false
+  caUrl: "step-certificates"
   caBundle: ""
   provisioner:
     name: ""


### PR DESCRIPTION
## Description
This PR adds a `caUrl` Helm parameter that provides the option of custom step-certificates service names. 

This is so that the automatic creation of StepIssuer/StepClusterIssuer via Helm is not limited to the `step-certificates` service name and URL.

Chart default functionality has not changed as the `caUrl` default remains the same `step-certificates`.

### Other
README updates to reflect this and previous changes.