### PR TITLE
🐛 Invalid KMS Configuration Parameter in `step-certificates` Chart README

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -202,7 +202,7 @@ chart and their default values.
 | `ca.db.accessModes`           | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
 | `ca.db.size`                  | Persistent volume size                                                                                      | `10Gi`                                   |
 | `ca.db.existingClaim`         | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
-| `ca.kms`                      | Key management system to use.                                                                               | `""`                                     |
+| `ca.kms.type`                      | Key management system to use.                                                                               | `""`                                     |
 | `ca.env`                      | Environment variables to set in `step-certificates` container.                                              | `[]`                                     |
 | `ca.runAsRoot`                | Run the CA as root.                                                                                         | `false`                                  |
 | `ca.bootstrap.postInitHook`   | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -202,7 +202,7 @@ chart and their default values.
 | `ca.db.accessModes`           | Persistent volume access mode                                                                               | `["ReadWriteOnce"]`                      |
 | `ca.db.size`                  | Persistent volume size                                                                                      | `10Gi`                                   |
 | `ca.db.existingClaim`         | Persistent volume existing claim name. If defined, PVC must be created manually before volume will be bound | `""`                                     |
-| `ca.kms.type`                      | Key management system to use.                                                                               | `""`                                     |
+| `ca.kms.type`                 | Key management system to use.                                                                               | `""`                                     |
 | `ca.env`                      | Environment variables to set in `step-certificates` container.                                              | `[]`                                     |
 | `ca.runAsRoot`                | Run the CA as root.                                                                                         | `false`                                  |
 | `ca.bootstrap.postInitHook`   | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |


### PR DESCRIPTION
### Description
This PR fixes an invalid KMS configuration parameter in the README for the `step-certificates` chart. The parameter is listed as `ca.kms`, however `ca.kms.type` is expected by the chart.

### Changelog
* step-certificates: Rename configuration parameter: 'ca.kms' -> 'ca.kms.type' (README.md)
