### PR TITLE
fix: Prometheus scrape port Service annotation

### DIFF
--- a/step-issuer/templates/service.yaml
+++ b/step-issuer/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "step-issuer.fullname" . }}"
   namespace: {{ .Release.Namespace }}
   annotations:
-    prometheus.io/port: "{{ .Values.service.ports }}"
+    prometheus.io/port: "{{ .Values.service.scrapePort }}"
     prometheus.io/scheme: "{{ .Values.service.targetPorts }}"
     prometheus.io/scrape: "{{ .Values.service.scrape }}"
   labels:

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -42,6 +42,7 @@ service:
   targetPorts: https
   controlPlane: controller-manager
   scrape: true
+  scrapePort: 8080
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
### Description
This PR fixes #112 
- add new Helm value `scrapePort`
- fix Service `prometheus.io/port` annotation to use the correct metrics port
