### PR TITLE
feat(step-certificates): add pod extra-labels

### DIFF
--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "step-certificates.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.podExtraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.inject.enabled }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -46,6 +46,9 @@ bootstrap:
   # secrets defines if the secrets are created.
   secrets: true
 
+# Extra labels
+podExtraLabels: {}
+
 # inject contains values to be injected into config maps and secrets
 inject:
   enabled: false


### PR DESCRIPTION
 It gives the possibility to the user to add extra-labels to the pod
 according to its use case. This can be usefull when we deal with azure
 resources (exp: KeyVault to store the private keys) and managed identity
 to allow the access to those resources.

 **How to use it:**
  - Add podExtraLabels to values.yaml:

 exemple:
 podExtraLabels: {
   aadpodidbinding: ${Identity_Name} 
}

