### PR TITLE
Fix smallstep/step-cli image

### DIFF
--- a/docker/step-ca-bootstrap/Dockerfile
+++ b/docker/step-ca-bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM smallstep/step-cli:0.22.1
+FROM smallstep/step-cli:0.22.0
 
 ENV CA_NAME="Step CA"
 ENV CA_DNS="127.0.0.1"


### PR DESCRIPTION
### Description

This PR changes the image tag of step-cli to the latest version 0.22.0