### PR TITLE
Fix step-certificates.enabled

### DIFF
--- a/autocert/Chart.yaml
+++ b/autocert/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: autocert
 version: 1.16.4
 appVersion: 0.16.0


### PR DESCRIPTION
The dependencies section of Chart.yaml is ignored with apiVersion v1. This makes it impossible to disable the step-certificates subchart using `--set step-certificates.enabled=false` as shown in the autocert README.

### Description
Please describe your pull request.

💔Thank you!
