### PR TITLE
Allows creation of a serviceaccount to run the service

### DIFF
--- a/step-certificates/templates/_helpers.tpl
+++ b/step-certificates/templates/_helpers.tpl
@@ -84,3 +84,15 @@ Linked CA variables
 token
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "step-certificates.serviceaccountname" -}}
+{{- if .Values.serviceaccount.create -}}
+    {{ default (include "step-certificates.fullname" .) .Values.serviceaccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceaccount.name }}
+{{- end -}}
+{{- end -}}
+

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -29,6 +29,9 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       {{- end }}
     spec:
+      {{- if or .Values.serviceaccount.create ( not (eq .Values.serviceaccount.name "")) }}
+      serviceAccountName: {{ template "step-certificates.serviceaccountname" . }}
+      {{- end }}
       {{- if and .Release.IsInstall (not (or .Values.inject.enabled .Values.existingSecrets.enabled )) }}
       initContainers:
         - name: {{ .Chart.Name }}-init

--- a/step-certificates/templates/serviceaccount.yaml
+++ b/step-certificates/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceaccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "step-certificates.serviceaccountname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
+    {{- with .Values.serviceaccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceaccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -319,3 +319,10 @@ tolerations: []
 
 # affinity contains the affinity settings for pod assignment.
 affinity: {}
+
+# create or use a service account for running the ca. Useful for oidc access to kms for example
+serviceaccount:
+  create: false
+  name: ""
+  labels: {}
+  annotations: {}


### PR DESCRIPTION
### Description
Hello,
This little patch allows the creation of a service account which will be used to run the statefulset ( or deployment ).
This is useful when using kms on eks for example, as the service account will have the annotations to allow for oidc access to aws kms. This is the standard now instead of kube2iam and the like.

Typically you configure the annotation on the service like this:
`
eks.amazonaws.com/role-arn: arn:aws:iam::*:role/<the role you created with trust policy and policy to allow access to kms>
`

💔Thank you!
