### PR TITLE
Fix indentation of security contexts

### DIFF
--- a/step-certificates/templates/bootstrap.yaml
+++ b/step-certificates/templates/bootstrap.yaml
@@ -40,11 +40,11 @@ spec:
             readOnly: true
         {{- with .Values.bootstrap.containerSecurityContext }}
         securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-      {{- if .Values.podSecurityContext }}
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description

This PR unifies the indentation of security contexts from PR #118, and hides an empty securityContext if none is provided.