### PR TITLE
Add support for `ca.ssh.enabled`

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -229,6 +229,7 @@ chart and their default values.
 | `ca.bootstrap.postInitHook`   | Extra script snippet to run after `step ca init` has completed.                                             | `""`                                     |
 | `ca.init.containerSecurityContext`    | Set SecurityContext for the STEP CA init container                                                  | See [values.yaml](./values.yaml)         |
 | `ca.containerSecurityContext`         | Set SecurityContext for the STEP CA container                                                       | See [values.yaml](./values.yaml)         |
+| `ca.ssh.enabled`              | If true, step certificates will be configured with ssh support enabled                                      | `false`                                  |
 | `linkedca.token`              | The token used to configure step-ca using the linkedca mode.                                                | `""`                                     |
 | `linkedca.secretKeyRef.name`  | The secret name where the linkedca token can be found.                                                      | `""`                                     |
 | `linkedca.secretKeyRef.key`   | The secret key where the linkedca token can be found.                                                       | `""`                                     |

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -137,6 +137,11 @@ spec:
             mountPath: /home/step/secrets/ssh-user-ca
             readOnly: true
           {{- end }}
+          {{- if .Values.ca.ssh.enabled }}
+          - name: templates-ssh
+            mountPath: /home/step/templates/ssh
+            readOnly: true
+          {{- end }}
           {{- with .Values.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -188,6 +193,11 @@ spec:
       - name: database
         persistentVolumeClaim:
           claimName: {{ .Values.ca.db.existingClaim }}
+      {{- end }}
+      {{- if .Values.ca.ssh.enabled }}
+      - name: templates-ssh
+        configMap:
+          name: {{ include "step-certificates.fullname" . }}-templates-ssh
       {{- end }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -59,6 +59,16 @@ data:
 {{- end }}
 {{- end }}
 ---
+{{- if .Values.ca.ssh.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-templates-ssh
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
+{{- end }}
+---
 {{- if and .Values.bootstrap.configmaps (not .Values.inject.enabled) }}
 apiVersion: v1
 kind: ConfigMap
@@ -146,6 +156,7 @@ data:
 
     step ca init \
       --name "{{.Values.ca.name}}" \
+     {{- if .Values.ca.ssh.enabled }}--ssh \{{ end }}
       --dns "{{include "step-certificates.dns" .}}" \
       --address "{{.Values.ca.address}}" \
       --provisioner "{{.Values.ca.provisioner.name}}" \
@@ -167,6 +178,9 @@ data:
     kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-config --from-file $(step path)/config
     kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-certs --from-file $(step path)/certs
     kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-secrets --from-file $(step path)/secrets
+    {{- if .Values.ca.ssh.enabled }}
+    kbreplace -n {{ .Release.Namespace }} create configmap {{ include "step-certificates.fullname" . }}-templates-ssh --from-file $(step path)/templates/ssh
+    {{- end }}
 
     kbreplace -n {{ .Release.Namespace }} create secret generic {{ include "step-certificates.fullname" . }}-ca-password --from-literal "password=${CA_PASSWORD}"
     kbreplace -n {{ .Release.Namespace }} create secret generic {{ include "step-certificates.fullname" . }}-provisioner-password --from-literal "password=${CA_PROVISIONER_PASSWORD}"
@@ -175,6 +189,9 @@ data:
     kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-config {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-certs {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-secrets {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
+    {{- if .Values.ca.ssh.enabled }}
+    kubectl -n {{ .Release.Namespace }} label configmap {{ include "step-certificates.fullname" . }}-templates-ssh {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
+    {{- end }}
     kubectl -n {{ .Release.Namespace }} label secret {{ include "step-certificates.fullname" . }}-ca-password {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
     kubectl -n {{ .Release.Namespace }} label secret {{ include "step-certificates.fullname" . }}-provisioner-password {{ include "step-certificates.labels" . | replace ": " "=" | replace "\n" " " }}
 

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -279,6 +279,9 @@ ca:
     - ReadWriteOnce
     # size is the Persistent Volume size.
     size: 10Gi
+  # Whether to enable ssh support for step-ca
+  ssh:
+    enabled: false
   # kms type to utilize 
   kms:
     type: ""


### PR DESCRIPTION
When enabled, `step ca init` is run with `--ssh` parameter, which avoids having to edit the configuration file to add ssh support as described in
https://github.com/smallstep/certificates/discussions/400#discussioncomment-106743

If this option is enabled, `step ca init` also creates a `templates/ssh` directory, which needs to be preserved.

Fixes https://github.com/smallstep/helm-charts/issues/134