### PR TITLE
step-certificates: expose Service externalIPs

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -238,6 +238,7 @@ chart and their default values.
 | `service.nodePort`            | Incoming port to access Step CA                                                                             | `""`                                     |
 | `service.targetPort`          | Internal port where Step CA runs                                                                            | `9000`                                   |
 | `service.annotations`         | Service annotations (YAML)                                                                                  | `{}`                                     |
+| `service.externalIPs`         | Service externalIPs                                                                                         | `[]`                                     |
 | `replicaCount`                | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
 | `image.repository`            | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
 | `image.initContainerRepository` | Repository of the Step CA Init Container image.                                                           | `busybox:latest`                         |

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -11,6 +11,10 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -225,6 +225,7 @@ service:
   targetPort: 9000
   nodePort: ""
   annotations: {}
+  externalIPs: []
 
 # linkedca contains the token to configure step-ca using the linkedca mode.
 #


### PR DESCRIPTION
### Description

This adds a new Helm value `service.externalIPs` to allow setting of step-certificates Service's externalIPs.

This is especially useful when deploying to bare-metal clusters without load balancers.