### PR TITLE
Use curl to perform step-certificates test

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.24.2
+version: 1.24.2+1
 appVersion: 0.24.2
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/templates/tests/test-connection.yaml
+++ b/step-certificates/templates/tests/test-connection.yaml
@@ -6,11 +6,15 @@ metadata:
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "step-certificates.fullname" . }}:{{ .Values.service.port }}']
+    - name: curl
+      image: alpine/curl
+      command:
+        - 'curl'
+      args:
+        - '-s'
+        - '-k'
+        - 'https://{{ include "step-certificates.fullname" . }}:{{ .Values.service.port }}/health'
   restartPolicy: Never


### PR DESCRIPTION
### Description

This commit replaces wget with curl to perform the test of step-certificates helm chart. Busybox wget doesn't support TLS 1.2, the handshake will fail and the CA prints the following error:
```
tls: invalid ClientKeyExchange message
```

Fixes #149