### PR TITLE
Allow the use of existing certs secret

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -126,6 +126,7 @@ existingSecrets:
   enabled: true
   ca: true
   issuer: true
+  certsAsSecret: true
   configAsSecret: true
   sshHostCa: true
   sshUserCa: true
@@ -161,6 +162,19 @@ which contains the following data:
   - The encrypted private key used to sign tokens used on RA mode. This is
     required if an X5C provisioner is used to talk with the CA, but it can also
     be used with JWK if the encrypted key is not distributed by the CA.
+
+When `existingSecrets.certsAsSecret` is `true`
+secret name: `{{ include "step-certificates.fullname" . }}-certs`
+which contains the following data:
+
+- `root_ca.crt`
+  - The root CA certificate.
+- `intermediate_ca.crt`
+  - The intermediate CA certificate (optional).
+- `ssh_host_ca_key.pub:`
+  - The SSH host CA public key (optional).
+- `ssh_user_ca_key.pub:`
+  - The SSH user CA public key (optional).
 
 When `existingSecrets.configAsSecret` is `true`
 secret name: `{{ include "step-certificates.fullname" . }}-config`
@@ -285,6 +299,7 @@ chart and their default values.
 | `existingSecrets.issuer`                  | When `true`use existing secret for the issuer.                                                  | `false`                                  |
 | `existingSecrets.sshHostCa`               | When `true`use existing secret for the ssh host CA public key.                                  | `false`                                  |
 | `existingSecrets.sshUserCa`               | When `true`use existing secret for the ssh user CA public key.                                  | `false`                                  |
+| `existingSecrets.certsAsSecret`           | When `true`use existing secret for certs instead of ConfigMap                                   | `false`                                  |
 | `existingSecrets.configAsSecret`          | When `true`use existing secret for configuration instead of ConfigMap                           | `false`                                  |
 | `podSecurityContext`                      | Set SecurityContext on POD level for STEP CA and STEP CA bootstrap job                          | See [values.yaml](./values.yaml)         |
 

--- a/step-certificates/examples/existing_secrets/values.yaml
+++ b/step-certificates/examples/existing_secrets/values.yaml
@@ -10,6 +10,7 @@ existingSecrets:
   enabled: true
   ca: true
   issuer: true
+  certsAsSecret: true
   configAsSecret: true
   sshHostCa: true
   sshUserCa: true

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -158,8 +158,13 @@ spec:
       {{- end }}
       volumes:
       - name: certs
+      {{- if and .Values.existingSecrets.enabled .Values.existingSecrets.certsAsSecret }}
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-certs
+      {{- else }}
         configMap:
           name: {{ include "step-certificates.fullname" . }}-certs
+      {{- end }}
       - name: config
       {{- if and .Values.existingSecrets.enabled .Values.existingSecrets.configAsSecret }}
         secret:

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -27,6 +27,7 @@ existingSecrets:
   enabled: false
   ca: false
   issuer: false
+  certsAsSecret: false
   configAsSecret: false
   sshHostCa: false
   sshUserCa: false


### PR DESCRIPTION
### Description

This is a small change that allows users to mount certs from an existing secret.
