### PR TITLE
Added Security context for charts that where missing them

### DIFF
--- a/autocert/Chart.yaml
+++ b/autocert/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: autocert
-version: 1.18.1
+version: 1.18.0+1
 appVersion: 0.18.0
 description: A kubernetes add-on that automatically injects TLS/HTTPS certificates into your containers.
 keywords:

--- a/autocert/Chart.yaml
+++ b/autocert/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: autocert
-version: 1.18.0
+version: 1.18.1
 appVersion: 0.18.0
 description: A kubernetes add-on that automatically injects TLS/HTTPS certificates into your containers.
 keywords:

--- a/autocert/templates/autocert.yaml
+++ b/autocert/templates/autocert.yaml
@@ -29,6 +29,8 @@ spec:
         imagePullPolicy: {{ .Values.autocert.image.pullPolicy }}
         resources: 
           {{- toYaml .Values.autocert.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.autocert.securityContext | nindent 10 }}
         env:
         - name: PROVISIONER_NAME
           value: {{ .Values.ca.provisioner.name | default "admin" }}
@@ -47,9 +49,6 @@ spec:
         - name: autocert-config
           mountPath: /home/step/autocert
           readOnly: true
-        securityContext:
-          runAsUser: 1000
-          allowPrivilegeEscalation: false
         livenessProbe:
           initialDelaySeconds: 5
           httpGet:
@@ -87,3 +86,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/autocert/values.yaml
+++ b/autocert/values.yaml
@@ -15,6 +15,10 @@ service:
   port: 443
   targetPort: 4443
 
+# Security Context for the pod
+podSecurityContext: {}
+  # fsGroup: 2000
+
 # autocert contains the configuration for autocert.
 autocert:
   # image contains the docker image for step-certificates.
@@ -42,6 +46,10 @@ autocert:
   tolerations: []
   # affinity contains the affinity settings for pod assignment.
   affinity: {}
+  # security context for container
+  securityContext:
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
 
 # bootstrapper contains the autocert-bootstrapper image and configuration.
 bootstrapper:

--- a/step-issuer/Chart.yaml
+++ b/step-issuer/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: step-issuer
 type: application
-version: 0.8.0+1
+version: 0.8.0+2
 appVersion: 0.8.0
 description: Step-issuer helm chart for kubernetes.
 home: https://smallstep.com
 dependencies:
 - name: crds
   condition: crds.enabled
-  version: 0.8.0+1
+  version: 0.8.0+2
 keywords:
  - authority
  - ca

--- a/step-issuer/charts/crds/Chart.yaml
+++ b/step-issuer/charts/crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: crds
 type: application
-version: 0.8.0+1
+version: 0.8.0+2
 appVersion: 0.8.0
 description: Step-issuer CRDs
 home: https://smallstep.com

--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
         ports:
         - containerPort: {{ .Values.service.port }}
           name: {{ .Values.service.targetPorts }}
+        securityContext:
+          {{- toYaml .Values.kubeRBACproxy.securityContext | nindent 10 }}
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: manager
@@ -48,6 +50,8 @@ spec:
           {{- end }}
         ]
         command: ["/manager"]
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         {{- if .Values.tunnel.enabled }}
         env:
           - name: STEP_TLS_TUNNEL
@@ -95,3 +99,5 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -14,7 +14,13 @@ kubeRBACproxy:
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: v0.8.0
+    tag: v0.15.0
+  # security context for container
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    # seccompProfile:
+    #   type: RuntimeDefault
 
 # List of secret keys used to pull images from private registries.
 imagePullSecrets: []
@@ -43,6 +49,17 @@ service:
   controlPlane: controller-manager
   scrape: true
   scrapePort: 8080
+
+# Security Context for the pod
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# security context for container
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  # seccompProfile:
+  #   type: RuntimeDefault
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
### Description
Added `securityContext` for both `step-issuer` and `autocert`, both at the pod level and individual containers
