### PR TITLE
Add optional network policy object for deploy of step-certificates

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -302,6 +302,9 @@ chart and their default values.
 | `existingSecrets.certsAsSecret`           | When `true`use existing secret for certs instead of ConfigMap                                   | `false`                                  |
 | `existingSecrets.configAsSecret`          | When `true`use existing secret for configuration instead of ConfigMap                           | `false`                                  |
 | `podSecurityContext`                      | Set SecurityContext on POD level for STEP CA and STEP CA bootstrap job                          | See [values.yaml](./values.yaml)         |
+| `networkpolicy.enabled`       | When `true` create the NetworkPolicy definition                                                             | `false`                                  |
+| `networkpolicy.annotations`   | Additional annotations to add to the NetworkPolicy definition                                               | `{}`                                     |
+| `networkpolicy.allow`         | If defined, restrict policy allow rule to only these CIDR subnets                                           | `[]`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/step-certificates/templates/policy.yaml
+++ b/step-certificates/templates/policy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.networkpolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "step-certificates.fullname" . }}-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
+  {{- with .Values.networkpolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector: 
+    matchLabels:
+      app.kubernetes.io/name: {{ include "step-certificates.name" . }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.service.targetPort }}
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      {{- if .Values.networkpolicy.allow }}
+    from:
+    {{- range .Values.networkpolicy.allow }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{- end }}
+    {{- end }}
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80
+{{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for step-certificates.
 
 # kind is the type of object to use when deploying the CA.
@@ -278,7 +279,7 @@ ca:
     # existingClaim: ""
     # accessModes defines the Persistent Volume Access Mode.
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     # size is the Persistent Volume size.
     size: 10Gi
   # Whether to enable ssh support for step-ca
@@ -387,3 +388,12 @@ podSecurityContext:
   fsGroup: 1000
   # seccompProfile:
   #   type: RuntimeDefault
+
+# Set up a network policy to allow incoming connections to the service
+# This is useful if your cluster has a default:deny policy set
+networkpolicy:
+  enabled: false
+  annotations: {}
+# Subnets to allow incoming access in CIDR format (eg: "10.0.0.0/8")
+# If not defined, allow all
+#  allow: []


### PR DESCRIPTION
### Description
This update to the helm template for step-certificates allows the optional creation of NetworkPolicy rules.

For users who have a Default-Deny policy rule on their kubernetes cluster (as we do) the normal deploy of a LoadBalancer Service will not be accessible from outside, and a Policy rule is required to permit the traffic.

Documentation is added to the Readme file and the values.yaml for the new available values.

Example
```
networkpolicy:
  enabled: true
  allow:
  -  "10.0.0.0/8"
```

In addition a couple of minor yaml formatting changes to make our automated yamllint a little happier.