### PR TITLE
Allow ssh templates to be used from existing secret

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: step-certificates
-version: 1.26.1
+version: 1.26.2
 appVersion: 0.26.1
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -227,10 +227,15 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.ca.db.existingClaim }}
       {{- end }}
-      {{- if .Values.ca.ssh.enabled }}
+      {{- if and .Values.ca.ssh.enabled ( not .Values.existingSecrets.sshTemplates ) }}
       - name: templates-ssh
         configMap:
           name: {{ include "step-certificates.fullname" . }}-templates-ssh
+      {{- end }}
+      {{ if .Values.existingSecrets.sshTemplates }}
+      - name: templates-ssh
+        secret:
+          secretName: {{ include "step-certificates.fullname" . }}-templates-ssh
       {{- end }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/step-certificates/templates/configmaps.yaml
+++ b/step-certificates/templates/configmaps.yaml
@@ -59,7 +59,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if .Values.ca.ssh.enabled }}
+{{- if and .Values.ca.ssh.enabled ( not .Values.existingSecrets.sshTemplates ) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -38,6 +38,7 @@ existingSecrets:
   configAsSecret: false
   sshHostCa: false
   sshUserCa: false
+  sshTemplates: false
 
 # bootstrap contains the docker image for bootstrapping the configurations.
 #


### PR DESCRIPTION
### Description
I want to use SSH template files from an already deployed secret as it is possible for the other configs
