### PR TITLE
feat(step-certificates): support adding additional entries with hostAliases

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -328,6 +328,7 @@ chart and their default values.
 | `existingSecrets.configAsSecret`          | When `true`use existing secret for configuration instead of ConfigMap.                          | `false`                                  |
 | `podSecurityContext`                      | Set SecurityContext on POD level for STEP CA and STEP CA bootstrap job.                         | See [values.yaml](./values.yaml)         |
 | `shareProcessNamespace`                   | Share a single process namespace between all of the containers in a pod.                        | `false`                                  |
+| `hostAliases`                             | Additional entries for `/etc/hosts`.                                                            | []                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -167,6 +167,10 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.imagePullSecrets }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -30,7 +30,7 @@ workingDir: "/home/step"
 
 # Use existing secrets instead of 'bootstrap' init-container or 'inject'-element from helm chart
 # Note, the MutatingWebhookConfiguration created by autocert is not patched with CA bundle as the bootstrap init-container is not run
-existingSecrets: 
+existingSecrets:
   enabled: false
   ca: false
   issuer: false
@@ -175,7 +175,7 @@ inject:
     # This value must be base64 encoded.
     ca_password: ""
     provisioner_password: ""
-    
+
     certificate_issuer:
       # enabled enables injection of certificate issuer certificates and keys when set to true.
       enabled: false
@@ -292,7 +292,7 @@ ca:
   # Whether to enable ssh support for step-ca
   ssh:
     enabled: false
-  # kms type to utilize 
+  # kms type to utilize
   kms:
     type: ""
   # additional environment variables to set in the step-certificates container
@@ -377,6 +377,13 @@ extraInitContainers: []
 ##     command: ['do', 'something']
 ##
 extraContainers: []
+
+## Configure additional entries for /etc/hosts.
+## hostAliases:
+##   - ip: 10.0.0.1
+##     hostnames:
+##       - host.domain.com
+hostAliases: []
 
 # shareProcessNamespace share a single process namespace between all of the
 # containers in a pod.


### PR DESCRIPTION
### Description
This PR adds a configuration parameter which allows adding extra entries for /etc/hosts using `hostAliases`. 

more information:
- https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases
