### PR TITLE
Bump certificates 0.26.3 move container registry to cr.smallstep.com

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: step-certificates
-version: 1.26.2
-appVersion: 0.26.2
+version: 1.26.3
+appVersion: 0.26.3
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:
  - acme

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -15,7 +15,7 @@ fullnameOverride: ""
 
 # image contains the docker image for step-certificates.
 image:
-  repository: cr.step.sm/smallstep/step-ca
+  repository: cr.smallstep.com/smallstep/step-ca
   initContainerRepository: busybox:latest
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -45,7 +45,7 @@ existingSecrets:
 # It's also possible to disable the creation of secrets and configmaps.
 bootstrap:
   image:
-    repository: cr.step.sm/smallstep/step-ca-bootstrap
+    repository: cr.smallstep.com/smallstep/step-ca-bootstrap
     tag: latest
     pullPolicy: IfNotPresent
   # enabled defines if the bootstrap job is created.


### PR DESCRIPTION
### Description
Please describe your pull request.

Updating chart to reflect deprecation of cr.step.sm in favor of cr.smallstep.com.