### PR TITLE
Add ability to annotate deployments & pods for autocert & step-issuer

### DIFF
--- a/autocert/templates/autocert.yaml
+++ b/autocert/templates/autocert.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "autocert.fullname" . }}
   labels: 
     {{- include "autocert.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -15,6 +19,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "autocert.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8}}
+      {{- end }}
     spec:
       {{- if and .Release.IsInstall (index .Values "step-certificates" "enabled") }}
       initContainers:

--- a/autocert/values.yaml
+++ b/autocert/values.yaml
@@ -19,6 +19,12 @@ service:
 podSecurityContext: {}
   # fsGroup: 2000
 
+# Deployment Annotations
+annotations: {}
+
+# Annotations to be added to deployment pods
+podAnnotations: {}
+
 # autocert contains the configuration for autocert.
 autocert:
   # image contains the docker image for step-certificates.

--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     control-plane: {{ .Values.service.controlPlane }}
     {{- include "step-issuer.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +21,10 @@ spec:
       labels:
         control-plane: {{ .Values.service.controlPlane }}
         {{- include "step-issuer.labels" . | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8}}
+      {{- end }}
     spec:
       {{- if $.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -27,6 +27,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Deployment Annotations
+annotations: {}
+
+# Annotations to be added to deployment pods
+podAnnotations: {}
+
 deployment:
   # Configure arguments to pass to the step issuer
   args:


### PR DESCRIPTION
### Description

Resolves Issue https://github.com/smallstep/helm-charts/issues/200 by adding to the templates the ability to annotate via 2 new values.

- annotations
- podAnnotations

These default to the current behaviour of not being added if they are not present or an empty map.