### PR TITLE
step-issuer: Allow to set deployment strategy

### DIFF
--- a/step-issuer/README.md
+++ b/step-issuer/README.md
@@ -52,6 +52,7 @@ and their default values.
 | `image.pullPolicy`                                     | Step Issuer image pull policy                                                                             | `IfNotPresent`                      |
 | `deployment.args.enableLeaderElection`                 | Enable k8s controller leader election.                                                                    | `true`                              |
 | `deployment.args.disableApprovalCheck`                 | To disable cert-manager approvals on old version of cert-manager.                                         | `false`                             |
+| `deployment.strategy`                                  | To change the deployment strategy.                                                                        | `{}`                             |
 | `stepIssuer.create`                                    | If we should automatically create a StepIssuer                                                            | `false`                             |
 | `stepIssuer.caUrl`                                     | Step Certificates CA URL. This is usually the step certificates service FQDN.                             | `""`                                |
 | `stepIssuer.caBundle`                                  | Step Certificates root certificate in a single-line base64 string.                                        | `""`                                |

--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
     control-plane: {{ .Values.service.controlPlane }}
     {{- include "step-issuer.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.updateStrategy }}
-  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+  {{- if .Values.deployment.strategy }}
+  strategy: {{ toYaml .Values.deployment.strategy | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     control-plane: {{ .Values.service.controlPlane }}
     {{- include "step-issuer.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.updateStrategy }}
+  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -33,6 +33,8 @@ deployment:
     enableLeaderElection: true
     disableApprovalCheck: false
   terminationGracePeriodSeconds: 10
+  # Strategy used for the deployment
+  strategy: {}
 
 resources:
   limits:
@@ -53,9 +55,6 @@ service:
 # Security Context for the pod
 podSecurityContext: {}
   # fsGroup: 2000
-
-# Strategy used for the deployment
-updateStrategy: {}
 
 # security context for container
 securityContext:

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -54,6 +54,9 @@ service:
 podSecurityContext: {}
   # fsGroup: 2000
 
+# Strategy used for the deployment
+updateStrategy: {}
+
 # security context for container
 securityContext:
   runAsUser: 1000


### PR DESCRIPTION
### Description
At the moment we are unable to set the deployment strategy for step-issuer. We plan to  run this deployment on control plane nodes with 3 replicas and the default strategy means we can't update the deployment.

❤Thank you!
