### PR TITLE
feat(step-certificates): enable dns settings for statefulset

### DIFF
--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -52,6 +52,13 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.ca.dnsPolicy }}
+      dnsPolicy: {{ .Values.ca.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.ca.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if  .Values.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- end }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -300,6 +300,10 @@ ca:
   bootstrap:
     # Add script snippets here to be executed after the step ca init has been run
     postInitHook: ""
+  # dns policy. See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: Default
+  # dns config. See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
   # Use existing secret for ca-password
   existingSecrets:
     enabled: false


### PR DESCRIPTION
### Description
This enables a user of the helm chart to overwrite dns settings for the step-certificates statefulset. 

We needed this in order for our custom workflow to work (using an azure private dns zone for dns validation without it being the real dns server for our private domain)

By default, these settings are the same as Kubernetes ships, so nothing should brake with previous releases.
