### PR TITLE
Fixed a minor misspelling of kubernetes in step-certificate values.yaml

### DIFF
--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -227,7 +227,7 @@ inject:
       user_ca_password: ""
 
 
-# service contains configuration for the kubernes service.
+# service contains configuration for the kubernetes service.
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
### Description
I noticed a single misspelling of the word `kubernetes` in the values.yaml file for the step-certificates chart and thought I would make my first contribution!
