### PR TITLE
feat(step-certificates): add custom labels support to service resource

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -276,6 +276,7 @@ chart and their default values.
 | `service.targetPort`          | Internal port where Step CA runs                                                                            | `9000`                                   |
 | `service.annotations`         | Service annotations (YAML)                                                                                  | `{}`                                     |
 | `service.externalIPs`         | Service externalIPs                                                                                         | `[]`                                     |
+| `service.labels`              | Custom labels to add to the service resource (YAML)                                                          | `{}`                                     |
 | `replicaCount`                | Number of Step CA replicas. Only one replica is currently supported.                                        | `1`                                      |
 | `image.repository`            | Repository of the Step CA image                                                                             | `cr.step.sm/smallstep/step-ca`           |
 | `image.initContainerRepository` | Repository of the Step CA Init Container image.                                                           | `busybox:latest`                         |
@@ -349,6 +350,29 @@ accessing the CA by those DNS/IPs will fail (services internal to the cluster):
 helm install --set ca.dns="ca.example.com\,my-release-step-certificates.default.svc.cluster.local\,127.0.0.1" \
   my-release smallstep/step-certificates
 ```
+
+### Service Customization
+
+You can add custom labels to the service resource for integration with service meshes, monitoring systems, or compliance requirements:
+
+```console
+helm install step-certificates smallstep/step-certificates \
+  --set service.labels.environment=production \
+  --set service.labels.team=platform
+```
+
+Or using a values file:
+
+```yaml
+service:
+  labels:
+    environment: production
+    team: platform
+    cost-center: engineering
+    compliance: nis2
+```
+
+**Note**: Custom labels are merged with standard Helm labels. Avoid using reserved Kubernetes label prefixes like `app.kubernetes.io/`, `helm.sh/`, or `kubernetes.io/`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be
 provided while installing the chart. For example,

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -94,6 +94,36 @@ helm install \
   step-certificates smallstep/step-certificates
 ```
 
+## Global Labels
+
+The `global.labels` configuration applies custom labels to every Kubernetes resource created by this chart. This is useful for:
+
+- Compliance and monitoring: Tag resources with environment, team, or cost-center information
+- GitOps and automation: Identify resources managed by this chart across clusters
+- Network policies and security: Label resources for access control rules
+
+Global labels are propagated to all subcharts (e.g., `autocert` when enabled). Per-resource labels (e.g., `service.labels`) are merged on top of global labels.
+
+Example:
+
+```console
+helm install \
+  --set global.labels.environment=production \
+  --set global.labels.team=platform \
+  --set global.labels.cost-center=engineering \
+  step-certificates smallstep/step-certificates
+```
+
+Or in a `values.yaml` file:
+
+```yaml
+global:
+  labels:
+    environment: production
+    team: platform
+    cost-center: engineering
+```
+
 ## Configuration
 
 The easiest way to configure step-certificates is to use [step](https://github.com/smallstep/cli).
@@ -249,6 +279,7 @@ chart and their default values.
 | `command`                     | The command entrypoint array                                                                                | `[]`                                     |
 | `args`                        | Arguments to the entrypoint                                                                                 | `[]`                                     |
 | `workingDir`                  | The container working directory                                                                             | `"/home/step"`                           |
+| `global.labels`               | Custom labels added to every resource in this chart and subcharts (YAML)                                    | `{}`                                     |
 | `ca.name`                     | Name for you CA                                                                                             | `Step Certificates`                      |
 | `ca.address`                  | TCP address where Step CA runs                                                                              | `:9000`                                  |
 | `ca.dns`                      | DNS of Step CA, if empty it will be inferred                                                                | `""`                                     |

--- a/step-certificates/templates/_helpers.tpl
+++ b/step-certificates/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.global.labels }}
+{{ toYaml . | trimSuffix "\n" }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/step-certificates/templates/bootstrap.yaml
+++ b/step-certificates/templates/bootstrap.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "step-certificates.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.global.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "step-certificates.fullname" . }}-config
       restartPolicy: Never

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "step-certificates.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.global.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podExtraLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/step-certificates/templates/rbac.yaml
+++ b/step-certificates/templates/rbac.yaml
@@ -5,11 +5,7 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
-    helm.sh/chart: {{ include "step-certificates.chart" . }}
-    app.kubernetes.io/name: {{ include "step-certificates.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "step-certificates.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["secrets", "configmaps"]
@@ -21,11 +17,7 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
-    helm.sh/chart: {{ include "step-certificates.chart" . }}
-    app.kubernetes.io/name: {{ include "step-certificates.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "step-certificates.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "step-certificates.fullname" . }}-config
@@ -41,11 +33,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "step-certificates.fullname" . }}-config
   labels:
-    helm.sh/chart: {{ include "step-certificates.chart" . }}
-    app.kubernetes.io/name: {{ include "step-certificates.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "step-certificates.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
@@ -57,11 +45,7 @@ metadata:
   name: {{ include "step-certificates.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
-    helm.sh/chart: {{ include "step-certificates.chart" . }}
-    app.kubernetes.io/name: {{ include "step-certificates.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "step-certificates.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "step-certificates.fullname" . }}-config

--- a/step-certificates/templates/secrets.yaml
+++ b/step-certificates/templates/secrets.yaml
@@ -11,6 +11,8 @@ type: smallstep.com/ca-password
 metadata:
   name: {{ include "step-certificates.fullname" . }}-ca-password
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 {{- if .Values.inject.enabled }}
 data:
   password: {{ .Values.inject.secrets.ca_password }}
@@ -26,6 +28,8 @@ type: smallstep.com/provisioner-password
 metadata:
   name: {{ include "step-certificates.fullname" . }}-provisioner-password
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 {{- if .Values.inject.enabled }}
 data:
   password: {{ .Values.inject.secrets.provisioner_password }}
@@ -39,6 +43,8 @@ type: smallstep.com/certificate-issuer-password
 metadata:
   name: {{ include "step-certificates.fullname" . }}-certificate-issuer-password
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 data:
   password: {{ .Values.inject.secrets.certificate_issuer.password }}
 {{- end }}
@@ -50,6 +56,8 @@ type: smallstep.com/ssh-host-ca-password
 metadata:
   name: {{ include "step-certificates.fullname" . }}-ssh-host-ca-password
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 data:
   password: {{ .Values.inject.secrets.ssh.host_ca_password }}
 {{- end }}
@@ -61,6 +69,8 @@ type: smallstep.com/ssh-user-ca-password
 metadata:
   name: {{ include "step-certificates.fullname" . }}-ssh-user-ca-password
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 data:
   password: {{ .Values.inject.secrets.ssh.user_ca_password }}
 {{- end }}
@@ -72,6 +82,8 @@ type: smallstep.com/private-keys
 metadata:
   name: {{ include "step-certificates.fullname" . }}-secrets
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 stringData:
   {{- if and .Values.inject.secrets.certificate_issuer.enabled (not (eq .Values.inject.secrets.certificate_issuer.key "")) }}
   certificate_issuer_key: |-
@@ -102,6 +114,8 @@ type: smallstep.com/step-ca-token
 metadata:
   name: {{ include "step-certificates.fullname" . }}-step-ca-token
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "step-certificates.labels" . | nindent 4 }}
 data:
   token: {{ .Values.linkedca.token }}
 {{- end }}

--- a/step-certificates/templates/service.yaml
+++ b/step-certificates/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "step-certificates.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -235,6 +235,14 @@ service:
   nodePort: ""
   annotations: {}
   externalIPs: []
+  # labels is a map of custom labels to add to the service resource.
+  # These labels are merged with the standard Helm labels.
+  # Example:
+  #   labels:
+  #     environment: production
+  #     team: platform
+  #     cost-center: engineering
+  labels: {}
 
 # linkedca contains the token to configure step-ca using the linkedca mode.
 #

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -1,5 +1,15 @@
 # Default values for step-certificates.
 
+# global values are propagated to all subcharts.
+global:
+  # labels is a map of custom labels added to every resource in this chart and subcharts.
+  # Per-resource labels (e.g. service.labels) are merged on top.
+  # Example:
+  #   labels:
+  #     environment: production
+  #     team: platform
+  labels: {}
+
 # kind is the type of object to use when deploying the CA.
 # Changing the deployment type is experimental.
 kind: StatefulSet


### PR DESCRIPTION
Add `global.labels` support to propagate custom labels to all chart resources, and `service.labels` for service-specific custom labels.

- `global.labels`: applied to all resources (Deployment, StatefulSet, Service, ServiceAccount, etc.)
- `service.labels`: applied only to the Service resource
- Follows existing pattern from `serviceaccount.labels`