### PR TITLE
Allow to define DNS configurations on step-certificates

### DIFF
--- a/step-certificates/Chart.yaml
+++ b/step-certificates/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: step-certificates
-version: 1.30.0
-appVersion: 0.30.0
+version: 1.30.2
+appVersion: 0.30.2
 description: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 keywords:
  - acme

--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -328,6 +328,7 @@ chart and their default values.
 | `existingSecrets.configAsSecret`          | When `true`use existing secret for configuration instead of ConfigMap.                          | `false`                                  |
 | `podSecurityContext`                      | Set SecurityContext on POD level for STEP CA and STEP CA bootstrap job.                         | See [values.yaml](./values.yaml)         |
 | `shareProcessNamespace`                   | Share a single process namespace between all of the containers in a pod.                        | `false`                                  |
+| `dnsConfig`                            | Custom DNS entries in `/etc/resolv.conf`.                                                          | {}                                       |
 | `hostAliases`                             | Additional entries for `/etc/hosts`.                                                            | []                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -167,6 +167,10 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
       {{- toYaml . | nindent 8 }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -378,6 +378,15 @@ extraInitContainers: []
 ##
 extraContainers: []
 
+## Configure DNS configuration
+## dnsConfig:
+##   nameservers:
+##     - 192.0.2.1 # this is an example
+##   searches:
+##     - ns1.svc.cluster-domain.example
+##     - my.dns.search.suffix
+dnsConfig: {}
+
 ## Configure additional entries for /etc/hosts.
 ## hostAliases:
 ##   - ip: 10.0.0.1


### PR DESCRIPTION
### Description

This PR allows to add the dnsConfig property to add custom nameservers or searches field in `/etc/resolv.conf`. It also updates the version of step-ca to the latest one.

Fixes #227
