### PR TITLE
step-certificates: make liveness and readiness probes configurable

### DIFF
--- a/step-certificates/README.md
+++ b/step-certificates/README.md
@@ -329,6 +329,8 @@ chart and their default values.
 | `podSecurityContext`                      | Set SecurityContext on POD level for STEP CA and STEP CA bootstrap job.                         | See [values.yaml](./values.yaml)         |
 | `shareProcessNamespace`                   | Share a single process namespace between all of the containers in a pod.                        | `false`                                  |
 | `hostAliases`                             | Additional entries for `/etc/hosts`.                                                            | []                                       |
+| `livenessProbe`                           | Liveness probe configuration. If empty, defaults to `initialDelaySeconds: 5` on `/health`.     | `{}`                                     |
+| `readinessProbe`                          | Readiness probe configuration. If empty, defaults to `initialDelaySeconds: 5` on `/health`.    | `{}`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,

--- a/step-certificates/templates/ca.yaml
+++ b/step-certificates/templates/ca.yaml
@@ -103,18 +103,28 @@ spec:
             - name: https
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           livenessProbe:
             initialDelaySeconds: 5
             httpGet:
               path: /health
               port: {{ .Values.service.targetPort }}
               scheme: HTTPS
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           readinessProbe:
             initialDelaySeconds: 5
             httpGet:
               path: /health
               port: {{ .Values.service.targetPort }}
               scheme: HTTPS
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.ca.containerSecurityContext }}

--- a/step-certificates/values.yaml
+++ b/step-certificates/values.yaml
@@ -398,6 +398,25 @@ tolerations: []
 # affinity contains the affinity settings for pod assignment.
 affinity: {}
 
+# livenessProbe contains the liveness probe configuration.
+# If not set, defaults to initialDelaySeconds: 5, httpGet on /health.
+# Override entirely to customize (e.g. increase initialDelaySeconds for slow startups).
+# livenessProbe:
+#   initialDelaySeconds: 30
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+livenessProbe: {}
+
+# readinessProbe contains the readiness probe configuration.
+# If not set, defaults to initialDelaySeconds: 5, httpGet on /health.
+# readinessProbe:
+#   initialDelaySeconds: 30
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+readinessProbe: {}
+
 # create or use a service account for running the ca. Useful for oidc access to kms for example
 serviceaccount:
   create: false


### PR DESCRIPTION
### Description

Fixes #249

Allows to either fully set liveness and readiness probes or uses old defaults if nothing is given.


