### PR TITLE
step-ca-bootstrap: bump step CLI to 0.30.2 and kubectl to 1.31.0

### DIFF
--- a/docker/step-ca-bootstrap/Dockerfile
+++ b/docker/step-ca-bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM smallstep/step-cli:0.22.0
+FROM smallstep/step-cli:0.30.2
 
 ENV CA_NAME="Step CA"
 ENV CA_DNS="127.0.0.1"
@@ -6,7 +6,7 @@ ENV CA_ADDRESS=":9000"
 ENV CA_DEFAULT_PROVISIONER="admin"
 ENV CA_URL="https://127.0.0.1:9000"
 
-ENV KUBE_LATEST_VERSION="v1.30.0"
+ENV KUBE_LATEST_VERSION="v1.31.0"
 
 USER root
 RUN apk --update add expect && \


### PR DESCRIPTION
The bootstrap image's `FROM smallstep/step-cli:0.22.0` line hadn't been updated since 2022. step-cli v0.22.0 predates several years of features — most notably the `--remote-management` flag on `step ca init`, which was introduced (under the original name `--remote-administration`) in v0.23.0 (smallstep/cli#736ea97e). The image's CI rebuilds on every tagged release, so the result is a `latest` image that still ships 0.22.0 verbatim.

Bumping the base to the current 0.30.2 release. Also bumping the kubectl version baked in alongside it from 1.30.0 to 1.31.0 to track the current minor.

Verified locally:
  docker build --platform linux/amd64 -t step-ca-bootstrap:test \
    docker/step-ca-bootstrap/
  docker run --rm step-ca-bootstrap:test step version
    Smallstep CLI/0.30.2 (linux/amd64)
  docker run --rm step-ca-bootstrap:test step ca init --help | grep remote
    --remote-management
  docker run --rm --entrypoint kubectl step-ca-bootstrap:test version --client
    Client Version: v1.31.0