### PR TITLE
Prepare release with step-issuer v0.11.0

### DIFF
--- a/step-issuer/Chart.yaml
+++ b/step-issuer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: step-issuer
 type: application
-version: 1.10.2
-appVersion: 0.10.2
+version: 1.11.0
+appVersion: 0.11.0
 description: Step-issuer helm chart for kubernetes.
 home: https://smallstep.com
 keywords:

--- a/step-issuer/crds/certmanager.step.sm_stepclusterissuers.yaml
+++ b/step-issuer/crds/certmanager.step.sm_stepclusterissuers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: stepclusterissuers.certmanager.step.sm
 spec:
   group: certmanager.step.sm
@@ -20,14 +20,19 @@ spec:
         description: StepClusterIssuer is the Schema for the stepclusterissuers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,9 +40,10 @@ spec:
             description: StepClusterIssuerSpec defines the desired state of StepClusterIssuer
             properties:
               caBundle:
-                description: CABundle is a base64 encoded TLS certificate used to
-                  verify connections to the step certificates server. If not set the
-                  system root certificates are used to validate the TLS connection.
+                description: |-
+                  CABundle is a base64 encoded TLS certificate used to verify connections
+                  to the step certificates server. If not set the system root certificates
+                  are used to validate the TLS connection.
                 format: byte
                 type: string
               provisioner:
@@ -50,10 +56,29 @@ spec:
                   name:
                     description: Names is the name of the JWK provisioner.
                     type: string
+                  passwordEnv:
+                    description: |-
+                      PasswordEnv is the name of an environment variable, read from the
+                      step-issuer controller's own environment, that holds the provisioner
+                      password. Use this when the password is injected into the controller pod
+                      (for example by Vault Agent) instead of being stored in a Kubernetes
+                      Secret. A trailing newline is trimmed. Exactly one of PasswordRef,
+                      PasswordEnv, or PasswordFile must be set.
+                    type: string
+                  passwordFile:
+                    description: |-
+                      PasswordFile is the path to a file, read from the step-issuer controller's
+                      own filesystem, that holds the provisioner password. Use this when the
+                      password is rendered into the controller pod (for example by a Vault Agent
+                      template) instead of being stored in a Kubernetes Secret. A trailing
+                      newline is trimmed. Exactly one of PasswordRef, PasswordEnv, or
+                      PasswordFile must be set.
+                    type: string
                   passwordRef:
-                    description: PasswordRef is a reference to a Secret containing
-                      the provisioner password used to decrypt the provisioner private
-                      key.
+                    description: |-
+                      PasswordRef is a reference to a Secret containing the provisioner
+                      password used to decrypt the provisioner private key. Exactly one of
+                      PasswordRef, PasswordEnv, or PasswordFile must be set.
                     properties:
                       key:
                         description: The key of the secret to select from. Must be
@@ -74,7 +99,6 @@ spec:
                 required:
                 - kid
                 - name
-                - passwordRef
                 type: object
               url:
                 description: URL is the base URL for the step certificates instance.
@@ -93,17 +117,20 @@ spec:
                     for the step issuer.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the timestamp corresponding
-                        to the last status change of this condition.
+                      description: |-
+                        LastTransitionTime is the timestamp corresponding to the last status
+                        change of this condition.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human readable description of the
-                        details of the last transition, complementing reason.
+                      description: |-
+                        Message is a human readable description of the details of the last
+                        transition, complementing reason.
                       type: string
                     reason:
-                      description: Reason is a brief machine readable explanation
-                        for the condition's last transition.
+                      description: |-
+                        Reason is a brief machine readable explanation for the condition's last
+                        transition.
                       type: string
                     status:
                       allOf:

--- a/step-issuer/crds/certmanager.step.sm_stepissuers.yaml
+++ b/step-issuer/crds/certmanager.step.sm_stepissuers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: stepissuers.certmanager.step.sm
 spec:
   group: certmanager.step.sm
@@ -20,14 +20,19 @@ spec:
         description: StepIssuer is the Schema for the stepissuers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,9 +40,10 @@ spec:
             description: StepIssuerSpec defines the desired state of StepIssuer
             properties:
               caBundle:
-                description: CABundle is a base64 encoded TLS certificate used to
-                  verify connections to the step certificates server. If not set the
-                  system root certificates are used to validate the TLS connection.
+                description: |-
+                  CABundle is a base64 encoded TLS certificate used to verify connections
+                  to the step certificates server. If not set the system root certificates
+                  are used to validate the TLS connection.
                 format: byte
                 type: string
               provisioner:
@@ -50,10 +56,29 @@ spec:
                   name:
                     description: Names is the name of the JWK provisioner.
                     type: string
+                  passwordEnv:
+                    description: |-
+                      PasswordEnv is the name of an environment variable, read from the
+                      step-issuer controller's own environment, that holds the provisioner
+                      password. Use this when the password is injected into the controller pod
+                      (for example by Vault Agent) instead of being stored in a Kubernetes
+                      Secret. A trailing newline is trimmed. Exactly one of PasswordRef,
+                      PasswordEnv, or PasswordFile must be set.
+                    type: string
+                  passwordFile:
+                    description: |-
+                      PasswordFile is the path to a file, read from the step-issuer controller's
+                      own filesystem, that holds the provisioner password. Use this when the
+                      password is rendered into the controller pod (for example by a Vault Agent
+                      template) instead of being stored in a Kubernetes Secret. A trailing
+                      newline is trimmed. Exactly one of PasswordRef, PasswordEnv, or
+                      PasswordFile must be set.
+                    type: string
                   passwordRef:
-                    description: PasswordRef is a reference to a Secret containing
-                      the provisioner password used to decrypt the provisioner private
-                      key.
+                    description: |-
+                      PasswordRef is a reference to a Secret containing the provisioner
+                      password used to decrypt the provisioner private key. Exactly one of
+                      PasswordRef, PasswordEnv, or PasswordFile must be set.
                     properties:
                       key:
                         description: The key of the secret to select from. Must be
@@ -69,7 +94,6 @@ spec:
                 required:
                 - kid
                 - name
-                - passwordRef
                 type: object
               url:
                 description: URL is the base URL for the step certificates instance.
@@ -88,17 +112,20 @@ spec:
                     for the step issuer.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the timestamp corresponding
-                        to the last status change of this condition.
+                      description: |-
+                        LastTransitionTime is the timestamp corresponding to the last status
+                        change of this condition.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human readable description of the
-                        details of the last transition, complementing reason.
+                      description: |-
+                        Message is a human readable description of the details of the last
+                        transition, complementing reason.
                       type: string
                     reason:
-                      description: Reason is a brief machine readable explanation
-                        for the condition's last transition.
+                      description: |-
+                        Reason is a brief machine readable explanation for the condition's last
+                        transition.
                       type: string
                     status:
                       allOf:

--- a/step-issuer/templates/stepclusterissuer.yaml
+++ b/step-issuer/templates/stepclusterissuer.yaml
@@ -16,8 +16,16 @@ spec:
   provisioner:
     name: {{ .Values.stepClusterIssuer.provisioner.name }}
     kid: {{ .Values.stepClusterIssuer.provisioner.kid }}
+    {{- if .Values.stepClusterIssuer.provisioner.passwordRef.name }}
     passwordRef:
       name: {{ .Values.stepClusterIssuer.provisioner.passwordRef.name }}
       namespace: {{ .Values.stepClusterIssuer.provisioner.passwordRef.namespace }}
       key: {{ .Values.stepClusterIssuer.provisioner.passwordRef.key }}
+    {{- else if .Values.stepClusterIssuer.provisioner.passwordEnv }}
+    passwordEnv: {{ .Values.stepClusterIssuer.provisioner.passwordEnv }}
+    {{- else if .Values.stepClusterIssuer.provisioner.passwordFile }}
+    passwordFile: {{ .Values.stepClusterIssuer.provisioner.passwordFile }}
+    {{- else }}
+    {{- fail "One of passwordRef, passwordEnv, or passwordFile must be set" }}
+    {{- end }}
 {{- end }}

--- a/step-issuer/templates/stepissuer.yml
+++ b/step-issuer/templates/stepissuer.yml
@@ -17,7 +17,15 @@ spec:
   provisioner:
     name: {{ .Values.stepIssuer.provisioner.name }}
     kid: {{ .Values.stepIssuer.provisioner.kid }}
+    {{- if .Values.stepIssuer.provisioner.passwordRef.name }}
     passwordRef:
       name: {{ .Values.stepIssuer.provisioner.passwordRef.name }}
       key: {{ .Values.stepIssuer.provisioner.passwordRef.key }}
+    {{- else if .Values.stepIssuer.provisioner.passwordEnv }}
+    passwordEnv: {{ .Values.stepIssuer.provisioner.passwordEnv }}
+    {{- else if .Values.stepIssuer.provisioner.passwordFile }}
+    passwordFile: {{ .Values.stepIssuer.provisioner.passwordFile }}
+    {{- else }}
+    {{- fail "One of passwordRef, passwordEnv, or passwordFile must be set" }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR updates the CRDs with the provisioner secret options available in step-issuer v0.11.0. It adds the options to the StepIssuer and StepClusterIssuer, but it doesn't change the deployment to add support for the new passwordEnv or passwordFile options.
