### PR TITLE
feat(step-issuer): add extraInitContainers and extraContainers support

### DIFF
--- a/step-issuer/templates/deployment.yaml
+++ b/step-issuer/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- with $.Values.deployment.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -72,6 +76,9 @@ spec:
            # Extra volumeMounts
 {{ toYaml . | indent 10 }}
 {{- end }}
+      {{- with .Values.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       volumes:
         {{- if or .Values.tunnel.enabled }}
         # Tunnel configuration

--- a/step-issuer/values.yaml
+++ b/step-issuer/values.yaml
@@ -107,7 +107,11 @@ tunnel:
     secret:
       secretName: ""
 
-# Configure extra volumes and volume mounts as YAML expressions.
+# Configure extra init containers, sidecar containers, volumes, and volume
+# mounts as YAML expressions. Useful for injecting secret-agent sidecars
+# (e.g. Vault Agent) that render passwords for passwordFile/passwordEnv.
+extraInitContainers: []
+extraContainers: []
 volumes: false
 volumeMounts: false
 


### PR DESCRIPTION
### Description

Add `extraInitContainers` and `extraContainers` to the step-issuer chart values, allowing users to inject sidecar and init containers into the controller Deployment.

This is a natural companion to the `passwordFile`/`passwordEnv` feature added in step-issuer v0.11.0 ([PR #365](https://github.com/smallstep/step-issuer/pull/365)). Users who manage secrets with tools like HashiCorp Vault Agent need a way to inject the agent container that renders the password file into the pod. Without this, the only options are a kustomize post-render patch or the Vault Agent Injector webhook (which not all platforms run).

### Usage example

```yaml
extraInitContainers:
  - name: vault-agent-init
    image: vault:1.15
    env:
      - name: VAULT_ADDR
        value: https://vault.example.com
    volumeMounts:
      - name: vault-home
        mountPath: /home/vault

volumes:
  - name: vault-home
    emptyDir:
      medium: Memory

volumeMounts:
  - name: vault-home
    mountPath: /home/vault
```

Then in the StepIssuer CR:
```yaml
provisioner:
  passwordFile: /home/vault/secrets/provisioner-password
```

### Changes

- `values.yaml`: Added `extraInitContainers: []` and `extraContainers: []`
- `templates/deployment.yaml`: Render both in the pod spec when provided

Tested with `helm template` — renders correctly with and without values set.